### PR TITLE
ENH: Scale-dependent slope and curvature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Build status
 
 The following badge should say _build passing_. This means that all automated tests completed successfully for the master branch.
 
-[![Build Status](https://travis-ci.org/ComputationalMechanics/SurfaceTopography.svg?branch=master)](https://travis-ci.org/github/ComputationalMechanics/SurfaceTopography)
+[![Build Status](https://travis-ci.org/ContactEngineering/SurfaceTopography.svg?branch=master)](https://travis-ci.org/github/ContactEngineering/SurfaceTopography)
 
 Documentation
 -------------
 
-This README file contains a brief introduction into the code. The full documentation can be found at https://computationalmechanics.github.io/SurfaceTopography/.
+This README file contains a brief introduction into the code. The full documentation can be found at https://contactengineering.github.io/SurfaceTopography/.
 
 Funding
 -------

--- a/SurfaceTopography/Converters.py
+++ b/SurfaceTopography/Converters.py
@@ -166,7 +166,7 @@ class UniformlyInterpolatedLineScan(DecoratedTopography,
 
     @property
     def pixel_size(self):
-        return (s / r for s, r in zip(self.physical_sizes, self.nb_grid_pts))
+        return tuple(s / r for s, r in zip(self.physical_sizes, self.nb_grid_pts))
 
     @property
     def area_per_pt(self):

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -32,7 +32,7 @@ from ..HeightContainer import UniformTopographyInterface
 from ..HeightContainer import NonuniformLineScanInterface
 
 
-def scale_dependent_slope_1D(topography, **kwargs):
+def scale_dependent_curvature_1D(topography, **kwargs):
     r"""
     Compute the one-dimensional scale-dependent slope.
 
@@ -42,7 +42,7 @@ def scale_dependent_slope_1D(topography, **kwargs):
          :nowrap:
 
          \begin{equation}
-         h_\text{rms}^\prime(\lambda) = \left[2A(\lambda)\right]^{1/2}/\lambda
+         h_\text{rms}^\prime(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda^2
          \end{equation}
 
     where :math:`A(\lambda)` is the autocorrelation function.
@@ -62,10 +62,12 @@ def scale_dependent_slope_1D(topography, **kwargs):
         Slope. (Units: dimensionless)
     """  # noqa: E501
     r, A = topography.autocorrelation_1D(**kwargs)
-    return r[1:], np.sqrt(2 * A[1:]) / r[1:]
+    n = (len(r) + 1) // 2
+    # Important: The following expression relies on the fact that r is equally spaced!
+    return r[1:n], np.sqrt(8 * A[1:n] - 2 * A[2::2]) / r[1:n]
 
 
-def scale_dependent_slope_2D(topography, **kwargs):
+def scale_dependent_curvature_2D(topography, **kwargs):
     r"""
     Compute the two-dimensional, radially averaged scale-dependent slope.
 
@@ -75,7 +77,7 @@ def scale_dependent_slope_2D(topography, **kwargs):
          :nowrap:
 
          \begin{equation}
-         h_\text{rms}^\prime(\lambda) = \left[2A(\lambda)\right]^{1/2}/\lambda
+         h_\text{rms}^\prime(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda
          \end{equation}
 
     where :math:`A(\lambda)` is the autocorrelation function.
@@ -95,15 +97,15 @@ def scale_dependent_slope_2D(topography, **kwargs):
         Slope. (Units: dimensionless)
     """  # noqa: E501
     r, A = topography.autocorrelation_2D(**kwargs)
-    return r[1:], np.sqrt(2 * A[1:]) / r[1:]
-
+    n = (len(r) + 1) // 2
+    return r[1:n], np.sqrt(8 * A[1:n] - 2 * A[2::2]) / r[1:n]
 
 # Register analysis functions from this module
-UniformTopographyInterface.register_function('scale_dependent_slope_1D',
-                                             scale_dependent_slope_1D)
-NonuniformLineScanInterface.register_function('scale_dependent_slope_1D',
-                                              scale_dependent_slope_1D)
-UniformTopographyInterface.register_function('scale_dependent_slope_2D',
-                                             scale_dependent_slope_2D)
-NonuniformLineScanInterface.register_function('scale_dependent_slope_2D',
-                                              scale_dependent_slope_2D)
+UniformTopographyInterface.register_function('scale_dependent_curvature_1D',
+                                             scale_dependent_curvature_1D)
+NonuniformLineScanInterface.register_function('scale_dependent_curvature_1D',
+                                              scale_dependent_curvature_1D)
+UniformTopographyInterface.register_function('scale_dependent_curvature_2D',
+                                             scale_dependent_curvature_2D)
+NonuniformLineScanInterface.register_function('scale_dependent_curvature_2D',
+                                              scale_dependent_curvature_2D)

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -42,7 +42,7 @@ def scale_dependent_curvature_1D(topography, **kwargs):
          :nowrap:
 
          \begin{equation}
-         h_\text{rms}^\prime(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda^2
+         h_\text{rms}^{\prime\prime}(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda^2
          \end{equation}
 
     where :math:`A(\lambda)` is the autocorrelation function.
@@ -82,7 +82,7 @@ def scale_dependent_curvature_2D(topography, nbins=None):
          :nowrap:
 
          \begin{equation}
-         h_\text{rms}^\prime(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda
+         h_\text{rms}^{\prime\prime}(\lambda) = \left[8A(\lambda) - 2A(2\lambda)\right]^{1/2}/\lambda^2
          \end{equation}
 
     where :math:`A(\lambda)` is the autocorrelation function.

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -94,7 +94,7 @@ def scale_dependent_curvature_2D(topography, nbins=None):
     nbins : int
         Number of bins for radial average. Bins are automatically determined
         if set to None. Note: Returned array can be smaller than this because
-        bins without data points are discarded. (Default: None) 
+        bins without data points are discarded. (Default: None)
 
     Returns
     -------
@@ -112,6 +112,7 @@ def scale_dependent_curvature_2D(topography, nbins=None):
         n = nz[0]
     # Important: The following expression relies on the fact that r is equally spaced!
     return r[:n], np.sqrt(B[:n]) / r[:n] ** 2
+
 
 # Register analysis functions from this module
 UniformTopographyInterface.register_function('scale_dependent_curvature_1D',

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -28,6 +28,7 @@ Scale-dependent slope
 
 import numpy as np
 
+from ..common import radial_average
 from ..HeightContainer import UniformTopographyInterface
 from ..HeightContainer import NonuniformLineScanInterface
 
@@ -63,11 +64,13 @@ def scale_dependent_curvature_1D(topography, **kwargs):
     """  # noqa: E501
     r, A = topography.autocorrelation_1D(**kwargs)
     n = (len(r) + 1) // 2
+    r = r[1:n]
+    B = 8 * A[1:n] - 2 * A[2::2]
     # Important: The following expression relies on the fact that r is equally spaced!
-    return r[1:n], np.sqrt(8 * A[1:n] - 2 * A[2::2]) / r[1:n]
+    return r[B > 0], np.sqrt(B[B > 0]) / r[B > 0] ** 2
 
 
-def scale_dependent_curvature_2D(topography, **kwargs):
+def scale_dependent_curvature_2D(topography, nbins=100):
     r"""
     Compute the two-dimensional, radially averaged scale-dependent slope.
 
@@ -86,8 +89,9 @@ def scale_dependent_curvature_2D(topography, **kwargs):
     ----------
     topography : :obj:`SurfaceTopography` or :obj:`UniformLineScan`
         Container storing the uniform topography map
-    **kwargs : dict
-        Additional keyword parameters are passed on to `autocorrelation_2D`
+    nbins : int
+        Number of bins for radial average. Note: Returned array can be smaller
+        than this because bins without data points are discarded.
 
     Returns
     -------
@@ -96,9 +100,19 @@ def scale_dependent_curvature_2D(topography, **kwargs):
     slope : array
         Slope. (Units: dimensionless)
     """  # noqa: E501
-    r, A = topography.autocorrelation_2D(**kwargs)
-    n = (len(r) + 1) // 2
-    return r[1:n], np.sqrt(8 * A[1:n] - 2 * A[2::2]) / r[1:n]
+    _, _, A_xy = topography.autocorrelation_2D(return_map=True)
+    nx, ny = A_xy.shape
+    nx = (nx + 1) // 2
+    ny = (ny + 1) // 2
+
+    sx, sy = topography.physical_sizes
+    B_xy = 8 * A_xy[1:nx, 1:ny] - 2 * A_xy[2::2, 2::2]
+    # Radial average
+    r_edges, n, r_val, B_val = radial_average(
+        # pylint: disable=invalid-name
+        B_xy, (sx + sy) / 2, nbins, physical_sizes=(sx, sy), full=False)
+
+    return r_val[B_val > 0], np.sqrt(B_val[B_val > 0]) / r_val[B_val > 0]
 
 # Register analysis functions from this module
 UniformTopographyInterface.register_function('scale_dependent_curvature_1D',
@@ -107,5 +121,3 @@ NonuniformLineScanInterface.register_function('scale_dependent_curvature_1D',
                                               scale_dependent_curvature_1D)
 UniformTopographyInterface.register_function('scale_dependent_curvature_2D',
                                              scale_dependent_curvature_2D)
-NonuniformLineScanInterface.register_function('scale_dependent_curvature_2D',
-                                              scale_dependent_curvature_2D)

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -28,7 +28,6 @@ Scale-dependent slope
 
 import numpy as np
 
-from ..common import radial_average
 from ..HeightContainer import UniformTopographyInterface
 from ..HeightContainer import NonuniformLineScanInterface
 
@@ -73,7 +72,7 @@ def scale_dependent_curvature_1D(topography, **kwargs):
     return r[:n], np.sqrt(B[:n]) / r[:n] ** 2
 
 
-def scale_dependent_curvature_2D(topography, nbins=50, bin_edges='log'):
+def scale_dependent_curvature_2D(topography, nbins=None):
     r"""
     Compute the two-dimensional, radially averaged scale-dependent slope.
 
@@ -92,40 +91,27 @@ def scale_dependent_curvature_2D(topography, nbins=50, bin_edges='log'):
     ----------
     topography : :obj:`SurfaceTopography` or :obj:`UniformLineScan`
         Container storing the uniform topography map
-    nbins : int, optional
-        Number of bins for radial average. Note: Returned array can be smaller
-        than this because bins without data points are discarded.
-        (Default: 50)
-    bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
-        Edges used for binning the average. Specifying 'log' yields bins
-        equally spaced on a log scale, 'quadratic' yields bins with
-        similar number of data points and 'linear' yields linear bins.
-        Alternatively, it is possible to explicitly specify the bin edges.
-        If bin_edges are explicitly specified, then `rmax` and `nbins` is
-        ignored. (Default: 'log')
+    nbins : int
+        Number of bins for radial average. Bins are automatically determined
+        if set to None. Note: Returned array can be smaller than this because
+        bins without data points are discarded. (Default: None) 
 
     Returns
     -------
     r : array
         Distances. (Units: length)
     curvature : array
-        curvature. (Units: 1/length)
+        Curvature. (Units: 1/length)
     """  # noqa: E501
-    _, _, A_xy = topography.autocorrelation_2D(return_map=True)
-    nx, ny = A_xy.shape
-    nx = (nx + 1) // 2
-    ny = (ny + 1) // 2
-
-    sx, sy = topography.physical_sizes
-    B_xy = 8 * A_xy[1:nx, 1:ny] - 2 * A_xy[2::2, 2::2]
-    # Radial average
-    r_edges, n, r_val, B_val = radial_average(
-        # pylint: disable=invalid-name
-        B_xy, rmax=(sx + sy) / 2,
-        nbins=nbins, bin_edges=bin_edges,
-        physical_sizes=(sx, sy), full=False)
-
-    return r_val[B_val > 0], np.sqrt(B_val[B_val > 0]) / r_val[B_val > 0]
+    r, A = topography.autocorrelation_2D(nbins=nbins, bin_edges='linear')
+    n = (len(r) + 1) // 2
+    r = r[1:n]
+    B = 8 * A[1:n] - 2 * A[2::2]
+    nz = np.nonzero(B < 0)[0]
+    if len(nz) > 0:
+        n = nz[0]
+    # Important: The following expression relies on the fact that r is equally spaced!
+    return r[:n], np.sqrt(B[:n]) / r[:n] ** 2
 
 # Register analysis functions from this module
 UniformTopographyInterface.register_function('scale_dependent_curvature_1D',

--- a/SurfaceTopography/Generic/Curvature.py
+++ b/SurfaceTopography/Generic/Curvature.py
@@ -34,9 +34,9 @@ from ..HeightContainer import NonuniformLineScanInterface
 
 def scale_dependent_curvature_1D(topography, **kwargs):
     r"""
-    Compute the one-dimensional scale-dependent slope.
+    Compute the one-dimensional scale-dependent curvature.
 
-    The scale-dependent slope is given by
+    The scale-dependent curvature is given by
 
        .. math::
          :nowrap:
@@ -58,8 +58,8 @@ def scale_dependent_curvature_1D(topography, **kwargs):
     -------
     r : array
         Distances. (Units: length)
-    slope : array
-        Slope. (Units: dimensionless)
+    curvature : array
+        Curvature. (Units: 1/length)
     """  # noqa: E501
     r, A = topography.autocorrelation_1D(**kwargs)
     n = (len(r) + 1) // 2
@@ -74,9 +74,9 @@ def scale_dependent_curvature_1D(topography, **kwargs):
 
 def scale_dependent_curvature_2D(topography, nbins=None):
     r"""
-    Compute the two-dimensional, radially averaged scale-dependent slope.
+    Compute the two-dimensional, radially averaged scale-dependent curvature.
 
-    The scale-dependent slope is given by
+    The scale-dependent curvature is given by
 
        .. math::
          :nowrap:

--- a/SurfaceTopography/Generic/Slope.py
+++ b/SurfaceTopography/Generic/Slope.py
@@ -1,0 +1,107 @@
+#
+# Copyright 2021 Lars Pastewka
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""
+Scale-dependent slope
+"""
+
+import numpy as np
+
+from ..HeightContainer import UniformTopographyInterface
+from ..HeightContainer import NonuniformLineScanInterface
+
+
+def scale_dependent_slope_1D(topography, **kwargs):
+    r"""
+    Compute the one-dimensional scale-dependent slope.
+
+    The scale-dependent slope is given by
+
+       .. math::
+         :nowrap:
+
+         \begin{equation}
+         h_\text{rms}^\prime(\lambda) = \left[2A(\lambda)\right]^{1/2}/\lambda.
+         \end{equation}
+
+
+    Parameters
+    ----------
+    topography : :obj:`SurfaceTopography` or :obj:`UniformLineScan`
+        Container storing the uniform topography map
+    direction : int
+        Cartesian direction in which to compute the scale-dependent slope
+
+    Returns
+    -------
+    r : array
+        Distances. (Units: length)
+    slope : array
+        Slope. (Units: dimensionless)
+    """  # noqa: E501
+    r, A = topography.autocorrelation_1D(**kwargs)
+    return r[1:], np.sqrt(2 * A[1:]) / r[1:]
+
+
+def scale_dependent_slope_2D(topography, **kwargs):
+    r"""
+    Compute the two-dimensional, radially averaged scale-dependent slope.
+
+    The scale-dependent slope is given by
+
+       .. math::
+         :nowrap:
+
+         \begin{equation}
+         h_\text{rms}^\prime(\lambda) = \left[2A(\lambda)\right]^{1/2}/\lambda.
+         \end{equation}
+
+
+    Parameters
+    ----------
+    topography : :obj:`SurfaceTopography` or :obj:`UniformLineScan`
+        Container storing the uniform topography map
+    direction : int
+        Cartesian direction in which to compute the scale-dependent slope
+
+    Returns
+    -------
+    r : array
+        Distances. (Units: length)
+    slope : array
+        Slope. (Units: dimensionless)
+    """  # noqa: E501
+    r, A = topography.autocorrelation_2D(**kwargs)
+    return r[1:], np.sqrt(2 * A[1:]) / r[1:]
+
+
+# Register analysis functions from this module
+UniformTopographyInterface.register_function('scale_dependent_slope_1D',
+                                             scale_dependent_slope_1D)
+NonuniformLineScanInterface.register_function('scale_dependent_slope_1D',
+                                              scale_dependent_slope_1D)
+UniformTopographyInterface.register_function('scale_dependent_slope_2D',
+                                             scale_dependent_slope_2D)
+NonuniformLineScanInterface.register_function('scale_dependent_slope_2D',
+                                              scale_dependent_slope_2D)

--- a/SurfaceTopography/Generic/__init__.py
+++ b/SurfaceTopography/Generic/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2018, 2020 Lars Pastewka
+#           2015-2016 Till Junge
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""
+Module containing generic functions that work for both uniform and nonuniform
+topographies
+"""

--- a/SurfaceTopography/Nonuniform/Autocorrelation.py
+++ b/SurfaceTopography/Nonuniform/Autocorrelation.py
@@ -114,7 +114,7 @@ def height_difference_autocorrelation_1D(line_scan, algorithm='fft',
     ----------
     line_scan : :obj:`NonuniformLineScan`
         Container storing the nonuniform line scan.
-    algorithms : str
+    algorithm : str
         Algorithm to compute autocorrelation.
         * 'fft': Interpolates the nonuniform line scan on a grid and then uses
         the FFT to compute the autocorrelation. Scales O(N log N)

--- a/SurfaceTopography/Uniform/Autocorrelation.py
+++ b/SurfaceTopography/Uniform/Autocorrelation.py
@@ -34,7 +34,7 @@ from ..common import radial_average
 from ..HeightContainer import UniformTopographyInterface
 
 
-def autocorrelation_1D(topography, direction=0, subinterval=None):
+def autocorrelation_1D(topography, direction=0):
     r"""
     Compute the one-dimensional height-difference autocorrelation function
     (ACF).
@@ -61,8 +61,6 @@ def autocorrelation_1D(topography, direction=0, subinterval=None):
         Container storing the uniform topography map
     direction : int
         Cartesian direction in which to compute the ACF
-    subinterval : tuple of ints
-        Compute autocorrelation function only on this subinterval
 
     Returns
     -------
@@ -81,20 +79,8 @@ def autocorrelation_1D(topography, direction=0, subinterval=None):
         else:
             raise ValueError("Don't know how to handle direction "
                              "{}".format(direction))
-    is_periodic = topography.is_periodic
-    if subinterval is not None:
-        # If a subinterval is selected, the topography is automatically
-        # non-periodic
-        is_periodic = False
-        l, r = subinterval
-        p = p[l:r]
-        # Compute new sizes
-        dx = sx/nx
-        nx = len(p)
-        print(nx, l-r)
-        sx = nx*dx
 
-    if is_periodic:
+    if topography.is_periodic:
         # Compute height-height autocorrelation function from a convolution
         # using FFT. This is periodic by nature.
         surface_qy = np.fft.fft(p, axis=0)
@@ -152,16 +138,15 @@ def autocorrelation_2D(topography, nbins=None, bin_edges='log', return_map=False
         Container storing the (two-dimensional) topography map.
     nbins : int, optional
         Number of bins for radial average. Bins are automatically determined
-        if set to None. (Default: None) Note: Returned array can be smaller
-        than this because bins without data points are discarded.
-        (Default: None)
+        if set to None. Note: Returned array can be smaller than this because
+        bins without data points are discarded. (Default: None)
     bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
         Edges used for binning the average. Specifying 'log' yields bins
         equally spaced on a log scale, 'quadratic' yields bins with
         similar number of data points and 'linear' yields linear bins.
         Alternatively, it is possible to explicitly specify the bin edges.
-        If `bin_edges` are explicitly specified, then `rmax` and `nbins` is
-        ignored. (Default: 'log')
+        If `bin_edges` are explicitly specified, then `nbins` is ignored.
+        (Default: 'log')
     return_map : bool, optional
         Return full 2D autocorrelation map. (Default: False)
 

--- a/SurfaceTopography/Uniform/Autocorrelation.py
+++ b/SurfaceTopography/Uniform/Autocorrelation.py
@@ -142,7 +142,7 @@ def autocorrelation_1D(topography, direction=0, subinterval=None):
         return r, A
 
 
-def autocorrelation_2D(topography, nbins=100, return_map=False):
+def autocorrelation_2D(topography, nbins=50, bin_edges='log', return_map=False):
     """
     Compute height-difference autocorrelation function and radial average.
 
@@ -150,9 +150,17 @@ def autocorrelation_2D(topography, nbins=100, return_map=False):
     ----------
     topography : :obj:`SurfaceTopography`
         Container storing the (two-dimensional) topography map.
-    nbins : int
+    nbins : int, optional
         Number of bins for radial average. Note: Returned array can be smaller
-        than this because bins without data point are discarded.
+        than this because bins without data points are discarded.
+        (Default: 50)
+    bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
+        Edges used for binning the average. Specifying 'log' yields bins
+        equally spaced on a log scale, 'quadratic' yields bins with
+        similar number of data points and 'linear' yields linear bins.
+        Alternatively, it is possible to explicitly specify the bin edges.
+        If bin_edges are explicitly specified, then `rmax` and `nbins` is
+        ignored. (Default: 'log')
     return_map : bool, optional
         Return full 2D autocorrelation map. (Default: False)
 
@@ -185,7 +193,8 @@ def autocorrelation_2D(topography, nbins=100, return_map=False):
         # Radial average
         r_edges, n, r_val, A_val = radial_average(
             # pylint: disable=invalid-name
-            A_xy, (sx + sy) / 4, nbins, physical_sizes=(sx, sy))
+            A_xy, rmax=(sx + sy) / 4, nbins=nbins, bin_edges=bin_edges,
+            physical_sizes=(sx, sy))
     else:
         p = topography.heights()
 
@@ -211,7 +220,8 @@ def autocorrelation_2D(topography, nbins=100, return_map=False):
         # Radial average
         r_edges, n, r_val, A_val = radial_average(
             # pylint: disable=invalid-name
-            A_xy, (sx + sy) / 2, nbins, physical_sizes=(sx, sy), full=False)
+            A_xy, rmax=(sx + sy) / 2, nbins=nbins, bin_edges=bin_edges,
+            physical_sizes=(sx, sy), full=False)
 
     if return_map:
         return r_val[n > 0], A_val[n > 0], A_xy

--- a/SurfaceTopography/Uniform/Autocorrelation.py
+++ b/SurfaceTopography/Uniform/Autocorrelation.py
@@ -34,7 +34,7 @@ from ..common import radial_average
 from ..HeightContainer import UniformTopographyInterface
 
 
-def autocorrelation_1D(topography, direction=0):
+def autocorrelation_1D(topography, direction=0, subinterval=None):
     r"""
     Compute the one-dimensional height-difference autocorrelation function
     (ACF).
@@ -61,6 +61,8 @@ def autocorrelation_1D(topography, direction=0):
         Container storing the uniform topography map
     direction : int
         Cartesian direction in which to compute the ACF
+    subinterval : tuple of ints
+        Compute autocorrelation function only on this subinterval
 
     Returns
     -------
@@ -79,8 +81,20 @@ def autocorrelation_1D(topography, direction=0):
         else:
             raise ValueError("Don't know how to handle direction "
                              "{}".format(direction))
+    is_periodic = topography.is_periodic
+    if subinterval is not None:
+        # If a subinterval is selected, the topography is automatically
+        # non-periodic
+        is_periodic = False
+        l, r = subinterval
+        p = p[l:r]
+        # Compute new sizes
+        dx = sx/nx
+        nx = len(p)
+        print(nx, l-r)
+        sx = nx*dx
 
-    if topography.is_periodic:
+    if is_periodic:
         # Compute height-height autocorrelation function from a convolution
         # using FFT. This is periodic by nature.
         surface_qy = np.fft.fft(p, axis=0)
@@ -147,7 +161,7 @@ def autocorrelation_2D(topography, nbins=100, return_map=False):
     r : array
         Distances. (Units: length)
     A : array
-        Autocorrelation function. (Units: length**2)
+        Radially averaged autocorrelation function. (Units: length**2)
     A_xy : array
         2D autocorrelation function. Only returned if return_map=True.
         (Units: length**2)

--- a/SurfaceTopography/Uniform/Autocorrelation.py
+++ b/SurfaceTopography/Uniform/Autocorrelation.py
@@ -160,7 +160,7 @@ def autocorrelation_2D(topography, nbins=None, bin_edges='log', return_map=False
         equally spaced on a log scale, 'quadratic' yields bins with
         similar number of data points and 'linear' yields linear bins.
         Alternatively, it is possible to explicitly specify the bin edges.
-        If bin_edges are explicitly specified, then `rmax` and `nbins` is
+        If `bin_edges` are explicitly specified, then `rmax` and `nbins` is
         ignored. (Default: 'log')
     return_map : bool, optional
         Return full 2D autocorrelation map. (Default: False)

--- a/SurfaceTopography/Uniform/Autocorrelation.py
+++ b/SurfaceTopography/Uniform/Autocorrelation.py
@@ -142,7 +142,7 @@ def autocorrelation_1D(topography, direction=0, subinterval=None):
         return r, A
 
 
-def autocorrelation_2D(topography, nbins=50, bin_edges='log', return_map=False):
+def autocorrelation_2D(topography, nbins=None, bin_edges='log', return_map=False):
     """
     Compute height-difference autocorrelation function and radial average.
 
@@ -151,9 +151,10 @@ def autocorrelation_2D(topography, nbins=50, bin_edges='log', return_map=False):
     topography : :obj:`SurfaceTopography`
         Container storing the (two-dimensional) topography map.
     nbins : int, optional
-        Number of bins for radial average. Note: Returned array can be smaller
+        Number of bins for radial average. Bins are automatically determined
+        if set to None. (Default: None) Note: Returned array can be smaller
         than this because bins without data points are discarded.
-        (Default: 50)
+        (Default: None)
     bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
         Edges used for binning the average. Specifying 'log' yields bins
         equally spaced on a log scale, 'quadratic' yields bins with
@@ -187,9 +188,6 @@ def autocorrelation_2D(topography, nbins=50, bin_edges='log', return_map=False):
         # autocorrelation
         A_xy = A_xy[0, 0] - A_xy
 
-        if nbins is None:
-            return A_xy
-
         # Radial average
         r_edges, n, r_val, A_val = radial_average(
             # pylint: disable=invalid-name
@@ -213,9 +211,6 @@ def autocorrelation_2D(topography, nbins=50, bin_edges='log', return_map=False):
         # autocorrelation
         A_xy = (A0_xy - A_xy[:nx, :ny]) / (
                     (nx - np.arange(nx)).reshape(-1, 1) * (ny - np.arange(ny)).reshape(1, -1))
-
-        if nbins is None:
-            return A_xy
 
         # Radial average
         r_edges, n, r_val, A_val = radial_average(

--- a/SurfaceTopography/Uniform/Filtering.py
+++ b/SurfaceTopography/Uniform/Filtering.py
@@ -42,12 +42,12 @@ class WindowedUniformTopography(DecoratedUniformTopography):
         """
         window : str, optional
             Window for eliminating edge effect. See scipy.signal.get_window.
-            Default: no window for periodic Topographies, "hann" window for
-            nonperiodic Topographies
+            (Default: no window for periodic Topographies, "hann" window for
+            nonperiodic Topographies)
         direction : str, optional
             Direction in which the window is applied. Possible options are
             'x', 'y' and 'radial'. If set to None, it chooses 'x' for line
-            scans and 'radial' for topographies. Default: None
+            scans and 'radial' for topographies. (Default: None)
         """
         super().__init__(topography, info=info)
 
@@ -125,18 +125,16 @@ class WindowedUniformTopography(DecoratedUniformTopography):
     def heights(self):
         """ Computes the windowed topography.
         """
-        if self._window_data is None:
-            self._make_window()
-        if self._window_data is None:
+        if self.window_data() is None:
             return self.parent_topography.heights()
         else:
             direction = self._direction
             if direction is None:
                 direction = 'x' if self.parent_topography.dim == 1 else 'radial'
             if direction == 'x':
-                return (self._window_data * self.parent_topography.heights().T).T
+                return (self.window_data() * self.parent_topography.heights().T).T
             elif direction == 'y' or direction == 'radial':
-                return self._window_data * self.parent_topography.heights()
+                return self.window_data() * self.parent_topography.heights()
             else:
                 raise ValueError(f"Unknown direction '{self._direction}'.")
 

--- a/SurfaceTopography/Uniform/Filtering.py
+++ b/SurfaceTopography/Uniform/Filtering.py
@@ -60,7 +60,6 @@ class WindowedUniformTopography(DecoratedUniformTopography):
         self._window_data = None
 
         n = self.parent_topography.nb_grid_pts
-        s = self.parent_topography.physical_sizes
 
         try:
             nx, ny = n
@@ -84,14 +83,14 @@ class WindowedUniformTopography(DecoratedUniformTopography):
                 win *= np.sqrt(nx / (win ** 2).sum())
             elif direction == 'y':
                 if self.parent_topography.dim == 1:
-                    raise ValueError(f"Direction 'y' does not make sense for line scans.")
+                    raise ValueError("Direction 'y' does not make sense for line scans.")
                 # Get window from scipy.signal
                 win = get_window(window_name, ny)
                 # Normalize window
                 win *= np.sqrt(ny / (win ** 2).sum())
             elif direction == 'radial':
                 if self.parent_topography.dim == 1:
-                    raise ValueError(f"Direction 'radial' does not make sense for line scans.")
+                    raise ValueError("Direction 'radial' does not make sense for line scans.")
                 win = get_window_2D(window_name, nx, ny,
                                     self.parent_topography.physical_sizes)
                 # Normalize window

--- a/SurfaceTopography/Uniform/Filtering.py
+++ b/SurfaceTopography/Uniform/Filtering.py
@@ -125,16 +125,16 @@ class WindowedUniformTopography(DecoratedUniformTopography):
     def heights(self):
         """ Computes the windowed topography.
         """
-        if self.window_data() is None:
+        if self.window_data is None:
             return self.parent_topography.heights()
         else:
             direction = self._direction
             if direction is None:
                 direction = 'x' if self.parent_topography.dim == 1 else 'radial'
             if direction == 'x':
-                return (self.window_data() * self.parent_topography.heights().T).T
+                return (self.window_data * self.parent_topography.heights().T).T
             elif direction == 'y' or direction == 'radial':
-                return self.window_data() * self.parent_topography.heights()
+                return self.window_data * self.parent_topography.heights()
             else:
                 raise ValueError(f"Unknown direction '{self._direction}'.")
 

--- a/SurfaceTopography/Uniform/PowerSpectrum.py
+++ b/SurfaceTopography/Uniform/PowerSpectrum.py
@@ -29,10 +29,8 @@ Power-spectral density for uniform topographies.
 """
 
 import numpy as np
-from scipy.signal import get_window
 
 from ..common import radial_average
-from ..FFTTricks import get_window_2D
 from ..HeightContainer import UniformTopographyInterface
 
 

--- a/SurfaceTopography/Uniform/PowerSpectrum.py
+++ b/SurfaceTopography/Uniform/PowerSpectrum.py
@@ -68,23 +68,10 @@ def power_spectrum_1D(topography,  # pylint: disable=invalid-name
         nx, = n
         sx, = s
 
-    h = topography.heights()
-
-    if not topography.is_periodic and window is None:
-        window = "hann"
-
-    # Construct and apply window
-    if window is not None and window != 'None':
-        win = get_window(window, nx)
-        # Normalize window
-        win *= np.sqrt(nx / (win ** 2).sum())
-        h = (win * h.T).T
-
-    # Pixel physical_sizes
-    len0 = sx / nx
+    h = topography.window(window).heights()
 
     # Compute FFT and normalize
-    fourier_topography = len0 * np.fft.fft(h, axis=0)
+    fourier_topography = topography.area_per_pt * np.fft.fft(h, axis=0)
     dq = 2 * np.pi / sx
     q = dq * np.arange(nx // 2)
 
@@ -145,22 +132,10 @@ def power_spectrum_2D(topography, nbins=None,  # pylint: disable=invalid-name
     nx, ny = topography.nb_grid_pts
     sx, sy = topography.physical_sizes
 
-    if not topography.is_periodic and window is None:
-        window = "hann"
-
-    # Construct and apply window
-    if window is not None:
-        win = get_window_2D(window, nx, ny, topography.physical_sizes)
-        # Normalize window
-        if normalize_window:
-            win *= np.sqrt(nx * ny / (win ** 2).sum())
-        topography = win * topography[:, :]
-
-    # Pixel physical_sizes
-    area0 = (sx / nx) * (sy / ny)
+    h = topography.window(window=window, direction='radial').heights()
 
     # Compute FFT and normalize
-    surface_qk = area0 * np.fft.fft2(topography[:, :])
+    surface_qk = topography.area_per_pt * np.fft.fft2(h)
     C_qk = abs(surface_qk) ** 2 / (sx * sy)  # pylint: disable=invalid-name
 
     # Radial average

--- a/SurfaceTopography/Uniform/PowerSpectrum.py
+++ b/SurfaceTopography/Uniform/PowerSpectrum.py
@@ -103,7 +103,7 @@ def power_spectrum_1D(topography,  # pylint: disable=invalid-name
         return q, C_all.mean(axis=1)
 
 
-def power_spectrum_2D(topography, nbins=50,  # pylint: disable=invalid-name
+def power_spectrum_2D(topography, nbins=None,  # pylint: disable=invalid-name
                       bin_edges='log',
                       window=None, normalize_window=True,
                       return_map=False):
@@ -116,9 +116,10 @@ def power_spectrum_2D(topography, nbins=50,  # pylint: disable=invalid-name
     topography : :obj:`SurfaceTopography`
         Container storing the (two-dimensional) topography map.
     nbins : int, optional
-        Number of bins for radial average. Note: Returned array can be smaller
+        Number of bins for radial average. Bins are automatically determined
+        if set to None. (Default: None) Note: Returned array can be smaller
         than this because bins without data points are discarded.
-        (Default: 50)
+        (Default: None)
     bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
         Edges used for binning the average. Specifying 'log' yields bins
         equally spaced on a log scale, 'quadratic' yields bins with
@@ -161,9 +162,6 @@ def power_spectrum_2D(topography, nbins=50,  # pylint: disable=invalid-name
     # Compute FFT and normalize
     surface_qk = area0 * np.fft.fft2(topography[:, :])
     C_qk = abs(surface_qk) ** 2 / (sx * sy)  # pylint: disable=invalid-name
-
-    if nbins is None:
-        return C_qk
 
     # Radial average
     q_edges, n, q_val, C_val = radial_average(  # pylint: disable=invalid-name

--- a/SurfaceTopography/Uniform/PowerSpectrum.py
+++ b/SurfaceTopography/Uniform/PowerSpectrum.py
@@ -103,7 +103,8 @@ def power_spectrum_1D(topography,  # pylint: disable=invalid-name
         return q, C_all.mean(axis=1)
 
 
-def power_spectrum_2D(topography, nbins=100,  # pylint: disable=invalid-name
+def power_spectrum_2D(topography, nbins=50,  # pylint: disable=invalid-name
+                      bin_edges='log',
                       window=None, normalize_window=True,
                       return_map=False):
     """
@@ -114,9 +115,17 @@ def power_spectrum_2D(topography, nbins=100,  # pylint: disable=invalid-name
     ----------
     topography : :obj:`SurfaceTopography`
         Container storing the (two-dimensional) topography map.
-    nbins : int
+    nbins : int, optional
         Number of bins for radial average. Note: Returned array can be smaller
-        than this because bins without data point are discarded.
+        than this because bins without data points are discarded.
+        (Default: 50)
+    bin_edges : {'log', 'quadratic', 'linear', array_like}, optional
+        Edges used for binning the average. Specifying 'log' yields bins
+        equally spaced on a log scale, 'quadratic' yields bins with
+        similar number of data points and 'linear' yields linear bins.
+        Alternatively, it is possible to explicitly specify the bin edges.
+        If bin_edges are explicitly specified, then `rmax` and `nbins` is
+        ignored. (Default: 'log')
     window : str, optional
         Window for eliminating edge effect. See scipy.signal.get_window.
         (Default: None)
@@ -158,7 +167,8 @@ def power_spectrum_2D(topography, nbins=100,  # pylint: disable=invalid-name
 
     # Radial average
     q_edges, n, q_val, C_val = radial_average(  # pylint: disable=invalid-name
-        C_qk, 2 * np.pi * nx / (2 * sx), nbins,
+        C_qk, rmax=2 * np.pi * nx / (2 * sx),
+        nbins=nbins, bin_edges=bin_edges,
         physical_sizes=(2 * np.pi * nx / sx, 2 * np.pi * ny / sy))
 
     if return_map:

--- a/SurfaceTopography/Uniform/ScalarParameters.py
+++ b/SurfaceTopography/Uniform/ScalarParameters.py
@@ -89,13 +89,13 @@ def rms_slope(topography, short_wavelength_cutoff=None, window=None,
     window : str, optional
         Window for eliminating edge effect. See scipy.signal.get_window.
         Only used if short wavelength cutoff is set.
-        Default: no window for periodic Topographies, "hann" window for
-        nonperiodic Topographies
+        (Default: no window for periodic Topographies, "hann" window for
+        nonperiodic Topographies)
     direction : str, optional
         Direction in which the window is applied. Possible options are
         'x', 'y' and 'radial'. If set to None, it chooses 'x' for line
         scans and 'radial' for topographies. Only used if short wavelength
-        cutoff is set. Default: None
+        cutoff is set. (Default: None)
 
     Returns
     -------
@@ -137,13 +137,13 @@ def rms_laplacian(topography, short_wavelength_cutoff=None, window=None,
     window : str, optional
         Window for eliminating edge effect. See scipy.signal.get_window.
         Only used if short wavelength cutoff is set.
-        Default: no window for periodic Topographies, "hann" window for
-        nonperiodic Topographies
+        (Default: no window for periodic Topographies, "hann" window for
+        nonperiodic Topographies)
     direction : str, optional
         Direction in which the window is applied. Possible options are
         'x', 'y' and 'radial'. If set to None, it chooses 'x' for line
         scans and 'radial' for topographies. Only used if short wavelength
-        cutoff is set. Default: None
+        cutoff is set. (Default: None)
 
     Returns
     -------
@@ -189,13 +189,13 @@ def rms_curvature(topography, short_wavelength_cutoff=None, window=None,
     window : str, optional
         Window for eliminating edge effect. See scipy.signal.get_window.
         Only used if short wavelength cutoff is set.
-        Default: no window for periodic Topographies, "hann" window for
-        nonperiodic Topographies
+        (Default: no window for periodic Topographies, "hann" window for
+        nonperiodic Topographies)
     direction : str, optional
         Direction in which the window is applied. Possible options are
         'x', 'y' and 'radial'. If set to None, it chooses 'x' for line
         scans and 'radial' for topographies. Only used if short wavelength
-        cutoff is set. Default: None
+        cutoff is set. (Default: None)
 
     Returns
     -------

--- a/SurfaceTopography/Uniform/ScalarParameters.py
+++ b/SurfaceTopography/Uniform/ScalarParameters.py
@@ -74,7 +74,7 @@ def rms_height(topography, kind='Sq'):
         raise RuntimeError("Unknown rms height kind '{}'.".format(kind))
 
 
-def rms_slope(topography, short_wavelength_cutoff=None):
+def rms_slope(topography, short_wavelength_cutoff=None, window=None):
     """
     Compute the root mean square amplitude of the height gradient of a
     topography or line scan stored on a uniform grid.
@@ -85,6 +85,11 @@ def rms_slope(topography, short_wavelength_cutoff=None):
         SurfaceTopography object containing height information.
     short_wavelength_cutoff : float
         All wavelengths below this cutoff will be set to zero amplitude.
+    window : str, optional
+        Window for eliminating edge effect. See scipy.signal.get_window.
+        This is only used when specifying a short wavelength cutoff.
+        Default: no window for periodic Topographies, "hann" window for
+        nonperiodic Topographies
 
     Returns
     -------

--- a/SurfaceTopography/Uniform/ScalarParameters.py
+++ b/SurfaceTopography/Uniform/ScalarParameters.py
@@ -113,8 +113,7 @@ def rms_slope(topography, short_wavelength_cutoff=None, window=None,
         return np.sqrt((topography.derivative(1, mask_function=mask_function) ** 2).mean())
     elif topography.dim == 2:
         mask_function = None if short_wavelength_cutoff is None else \
-            lambda frequency: (frequency[0] ** 2 + frequency[1] ** 2) < \
-                              1 / short_wavelength_cutoff ** 2
+            lambda frequency: (frequency[0] ** 2 + frequency[1] ** 2) < 1 / short_wavelength_cutoff ** 2
         slx, sly = topography.derivative(1, mask_function=mask_function)
         return np.sqrt((slx ** 2 + sly ** 2).mean())
     else:
@@ -163,8 +162,7 @@ def rms_laplacian(topography, short_wavelength_cutoff=None, window=None,
         return np.sqrt((curv ** 2).mean())
     elif topography.dim == 2:
         mask_function = None if short_wavelength_cutoff is None else \
-            lambda frequency: (frequency[0] ** 2 + frequency[1] ** 2) < \
-                              1 / short_wavelength_cutoff ** 2
+            lambda frequency: (frequency[0] ** 2 + frequency[1] ** 2) < 1 / short_wavelength_cutoff ** 2
         curv = topography.derivative(2, mask_function=mask_function)
         return np.sqrt(((curv[0] + curv[1]) ** 2).mean())
     else:

--- a/SurfaceTopography/Uniform/common.py
+++ b/SurfaceTopography/Uniform/common.py
@@ -152,13 +152,14 @@ def derivative(topography, n, operator=None, periodic=None, mask_function=None):
         a simple upwind differences scheme will be applied to compute the
         derivative. A tuple contains the gradient, i.e. the derivative
         operators in the Cartesian directions for multidimensional fields.
-    periodic : bool
-        Override periodic flag from topography.
-    mask_function : function
+        (Default: None)
+    periodic : bool, optional
+        Override periodic flag from topography. (Default: None)
+    mask_function : function, optional
         A function that takes as argument the output of FFT.fftfreq and
         returns a mask that will be multiplied with the Fourier transformed
         topography. This can be used to implement Fourier filtering before
-        computing the derivative.
+        computing the derivative. (Default: None)
 
     Returns
     -------

--- a/SurfaceTopography/Uniform/common.py
+++ b/SurfaceTopography/Uniform/common.py
@@ -147,7 +147,7 @@ def derivative(topography, n, operator=None, periodic=None, mask_function=None):
         SurfaceTopography object containing height information.
     n : int
         Order of the derivative.
-    operator : muFFT.Derivative object or tuple of muFFT.Derivative objects
+    operator : :obj:`muFFT.Derivative` object or tuple of :obj:`muFFT.Derivative` objects
         Derivative operator used to compute the derivative. If unspecified,
         a simple upwind differences scheme will be applied to compute the
         derivative. A tuple contains the gradient, i.e. the derivative

--- a/SurfaceTopography/__init__.py
+++ b/SurfaceTopography/__init__.py
@@ -51,6 +51,7 @@ import SurfaceTopography.Nonuniform.Autocorrelation  # noqa: F401
 import SurfaceTopography.Nonuniform.ScalarParameters  # noqa: F401
 import SurfaceTopography.Nonuniform.PowerSpectrum  # noqa: F401
 import SurfaceTopography.Nonuniform.VariableBandwidth  # noqa: F401
+import SurfaceTopography.Generic.Slope  # noqa: F401
 
 try:
     from importlib.metadata import version

--- a/SurfaceTopography/__init__.py
+++ b/SurfaceTopography/__init__.py
@@ -51,6 +51,7 @@ import SurfaceTopography.Nonuniform.Autocorrelation  # noqa: F401
 import SurfaceTopography.Nonuniform.ScalarParameters  # noqa: F401
 import SurfaceTopography.Nonuniform.PowerSpectrum  # noqa: F401
 import SurfaceTopography.Nonuniform.VariableBandwidth  # noqa: F401
+import SurfaceTopography.Generic.Curvature  # noqa: F401
 import SurfaceTopography.Generic.Slope  # noqa: F401
 
 try:

--- a/SurfaceTopography/common.py
+++ b/SurfaceTopography/common.py
@@ -42,7 +42,8 @@ def radial_average(C_xy, rmax=None, nbins=None, bin_edges='log',
     C_xy : array_like
         2D-array of values to be averaged.
     rmax : float, optional
-        Maximum radius. (Default: None)
+        Maximum radius, is automatically determined from the range of the data
+        if not provided. (Default: None)
     nbins : int, optional
         Number of bins for averaging. Bins are automatically determined if set
         to None. (Default: None)

--- a/SurfaceTopography/common.py
+++ b/SurfaceTopography/common.py
@@ -30,7 +30,8 @@ Bin for small common helper function and classes
 import numpy as np
 
 
-def radial_average(C_xy, rmax=None, nbins=None, bin_edges='log', physical_sizes=None, full=True):
+def radial_average(C_xy, rmax=None, nbins=None, bin_edges='log',
+                   physical_sizes=None, log_factor=1.1, full=True):
     """
     Compute radial average of quantities reported on a 2D grid.
 
@@ -55,6 +56,9 @@ def radial_average(C_xy, rmax=None, nbins=None, bin_edges='log', physical_sizes=
     physical_sizes : (float, float), optional
         Physical size of the 2D grid. (Default: Size is equal to number of
         grid points.)
+    log_factor : float, optional
+        Factor between consecutive bin edges for log-spaced bins.
+        (Default: 1.1)
     full : bool
         Number of quadrants contained in data. (Default: True)
         True: Full radial average from 0 to 2*pi.
@@ -98,7 +102,7 @@ def radial_average(C_xy, rmax=None, nbins=None, bin_edges='log', physical_sizes=
             # which is the (minimal) size of a grid point
             # i.e. rmin = np.exp(np.log(rmin) + dl) - rmin
             # => dl = np.log(2)
-            nbins = int((np.log(rmax) - np.log(rmin)) / np.log(2)) + 1
+            nbins = int((np.log(rmax) - np.log(rmin)) / np.log(log_factor)) + 1
         dr_r = np.exp(np.linspace(np.log(rmin), np.log(rmax), nbins - 1))
     elif bin_edges == 'quadratic':
         # Quadratic -> similar statistics for each data point

--- a/test/test_autocorrelation.py
+++ b/test/test_autocorrelation.py
@@ -147,7 +147,7 @@ def test_uniform_brute_force_autocorrelation_2D():
     m = 11
     for surf in [Topography(np.ones([n, m]), (n, m), periodic=False),
                  Topography(np.random.random([n, m]), (n, m), periodic=False)]:
-        r, A, A_xy = surf.autocorrelation_2D(return_map=True)
+        r, A, A_xy = surf.autocorrelation_2D(nbins=100, return_map=True)
 
         nx, ny = surf.nb_grid_pts
         dir_A_xy = np.zeros([n, m])

--- a/test/test_autocorrelation.py
+++ b/test/test_autocorrelation.py
@@ -310,13 +310,3 @@ def test_brute_force_vs_fft():
                                             distances=r, ninterpolate=5)
     x = A[1:] / A2[1:]
     assert np.alltrue(np.logical_and(x > 0.98, x < 1.01))
-
-
-def test_scale_dependent_slope_1D():
-    nx = 1001
-    L = 7.3
-    qs = 2 * np.pi * 8 / L
-    t1 = UniformLineScan(np.sin(np.arange(nx) * L * qs / nx), L, periodic=True)
-
-    x, y = t1.scale_dependent_slope_1D()
-    assert_array_almost_equal(y, np.sqrt(1-np.cos(qs * x))/x)

--- a/test/test_autocorrelation.py
+++ b/test/test_autocorrelation.py
@@ -310,3 +310,13 @@ def test_brute_force_vs_fft():
                                             distances=r, ninterpolate=5)
     x = A[1:] / A2[1:]
     assert np.alltrue(np.logical_and(x > 0.98, x < 1.01))
+
+
+def test_scale_dependent_slope_1D():
+    nx = 1001
+    L = 7.3
+    qs = 2 * np.pi * 8 / L
+    t1 = UniformLineScan(np.sin(np.arange(nx) * L * qs / nx), L, periodic=True)
+
+    x, y = t1.scale_dependent_slope_1D()
+    assert_array_almost_equal(y, np.sqrt(1-np.cos(qs * x))/x)

--- a/test/test_autocorrelation.py
+++ b/test/test_autocorrelation.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+
 """
 Tests for autocorrelation function analysis
 """

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -204,5 +204,4 @@ def test_window_topography():
     t = Topography(h, physical_sizes=(sx, sy), periodic=False).window(direction='radial')
     np.testing.assert_almost_equal(t.heights()[0, 0], 0.0)
     np.testing.assert_almost_equal(t.heights()[nx//2, 0], 0.0)
-    #np.testing.assert_almost_equal(t.heights()[0, ny//2], 0.0)
     np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -187,11 +187,11 @@ def test_window_topography():
     sx, sy = 1.3, 1.7
     h = np.ones((nx, ny))
 
-    t = Topography(h, physical_sizes=(sx, sy), periodic=True).window()
+    t = Topography(h, physical_sizes=(sx, sy), periodic=True).window(direction='x')
     np.testing.assert_almost_equal(t.heights()[0, ny//2], 1.0)
     np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)
 
-    t = Topography(h, physical_sizes=(sx, sy), periodic=False).window()
+    t = Topography(h, physical_sizes=(sx, sy), periodic=False).window(direction='x')
     np.testing.assert_almost_equal(t.heights()[0, ny//2], 0.0)
     assert t.heights()[nx//2, 0] > 1.0
     np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -23,11 +23,13 @@
 # SOFTWARE.
 #
 
+import pytest
+
 import numpy as np
 
 import SurfaceTopography
 from SurfaceTopography.Generation import fourier_synthesis
-from SurfaceTopography import Topography
+from SurfaceTopography import Topography, UniformLineScan
 
 
 def test_longcut():
@@ -158,3 +160,49 @@ def test_mirror_stitch():
                                 [0, 1, 1, 0]
                                 ]
                                )
+
+
+def test_window_line_scan():
+    nx = 27
+    sx = 1.3
+    h = np.ones((nx,))
+
+    t = UniformLineScan(h, physical_sizes=(sx,), periodic=True).window()
+    np.testing.assert_almost_equal(t.heights()[0], 1.0)
+    np.testing.assert_almost_equal((t.heights()**2).sum() / nx, 1.0)
+
+    t = UniformLineScan(h, physical_sizes=(sx,), periodic=False).window()
+    np.testing.assert_almost_equal(t.heights()[0], 0.0)
+    np.testing.assert_almost_equal((t.heights()**2).sum() / nx, 1.0)
+
+    with pytest.raises(ValueError):
+        UniformLineScan(h, physical_sizes=(sx,), periodic=False).window(direction='y').window_data
+
+    with pytest.raises(ValueError):
+        UniformLineScan(h, physical_sizes=(sx,), periodic=False).window(direction='radial').window_data
+
+
+def test_window_topography():
+    nx, ny = 27, 13
+    sx, sy = 1.3, 1.7
+    h = np.ones((nx, ny))
+
+    t = Topography(h, physical_sizes=(sx, sy), periodic=True).window()
+    np.testing.assert_almost_equal(t.heights()[0, ny//2], 1.0)
+    np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)
+
+    t = Topography(h, physical_sizes=(sx, sy), periodic=False).window()
+    np.testing.assert_almost_equal(t.heights()[0, ny//2], 0.0)
+    assert t.heights()[nx//2, 0] > 1.0
+    np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)
+
+    t = Topography(h, physical_sizes=(sx, sy), periodic=False).window(direction='y')
+    np.testing.assert_almost_equal(t.heights()[nx//2, 0], 0.0)
+    assert t.heights()[0, ny//2] > 1.0
+    np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)
+
+    t = Topography(h, physical_sizes=(sx, sy), periodic=False).window(direction='radial')
+    np.testing.assert_almost_equal(t.heights()[0, 0], 0.0)
+    np.testing.assert_almost_equal(t.heights()[nx//2, 0], 0.0)
+    #np.testing.assert_almost_equal(t.heights()[0, ny//2], 0.0)
+    np.testing.assert_almost_equal((t.heights()**2).sum() / (nx*ny), 1.0)

--- a/test/test_slope.py
+++ b/test/test_slope.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2019-2020 Lars Pastewka
+#           2019 Antoine Sanner
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""
+Tests for scale-dependent slope analysis
+"""
+
+import numpy as np
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
+
+from SurfaceTopography.Generation import fourier_synthesis
+
+
+def test_slope():
+    nb_grid_pts = (128, 128)
+    physical_sizes = (1.2, 2.1)
+    Hurst = 0.8
+    slope = 0.1
+
+    t = fourier_synthesis(nb_grid_pts, physical_sizes, Hurst,
+                          rms_slope=slope,
+                          short_cutoff=0.1*np.mean(physical_sizes))
+
+    r, s = t.scale_dependent_slope_1D()
+
+    px, py = t.pixel_size
+
+    np.testing.assert_almost_equal(s[0], np.sqrt(np.mean((np.diff(t.heights(), axis=0)/px)**2)), decimal=4)
+
+    r2, s2 = t.scale_dependent_slope_2D()
+
+    np.testing.assert_almost_equal(s[0], s2[0])

--- a/test/test_slope.py
+++ b/test/test_slope.py
@@ -28,7 +28,7 @@ Tests for scale-dependent slope analysis
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import assert_almost_equal
 
 from SurfaceTopography.Generation import fourier_synthesis
 
@@ -47,8 +47,9 @@ def test_slope():
 
     px, py = t.pixel_size
 
-    np.testing.assert_almost_equal(s[0], np.sqrt(np.mean((np.diff(t.heights(), axis=0)/px)**2)), decimal=4)
+    rms_slope = np.sqrt(np.mean(((np.roll(t.heights(), 1, 0) - t.heights())/px)**2))
+    assert_almost_equal(s[0], rms_slope)
 
     r2, s2 = t.scale_dependent_slope_2D()
 
-    np.testing.assert_almost_equal(s[0], s2[0])
+    assert_almost_equal(s[0], s2[0])

--- a/test/test_slope.py
+++ b/test/test_slope.py
@@ -28,8 +28,9 @@ Tests for scale-dependent slope analysis
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
+from SurfaceTopography import UniformLineScan
 from SurfaceTopography.Generation import fourier_synthesis
 
 

--- a/test/test_slope.py
+++ b/test/test_slope.py
@@ -33,7 +33,7 @@ from numpy.testing import assert_almost_equal
 from SurfaceTopography.Generation import fourier_synthesis
 
 
-def test_slope():
+def test_limiting_values():
     nb_grid_pts = (128, 128)
     physical_sizes = (1.2, 2.1)
     Hurst = 0.8
@@ -53,3 +53,13 @@ def test_slope():
     r2, s2 = t.scale_dependent_slope_2D()
 
     assert_almost_equal(s[0], s2[0])
+
+
+def test_numeric_vs_analytical():
+    nx = 1001
+    L = 7.3
+    qs = 2 * np.pi * 8 / L
+    t1 = UniformLineScan(np.sin(np.arange(nx) * L * qs / nx), L, periodic=True)
+
+    x, y = t1.scale_dependent_slope_1D()
+    assert_array_almost_equal(y, np.sqrt(1-np.cos(qs * x))/x)


### PR DESCRIPTION
This PR implements pipeline functions to compute scale-dependent slope and curvature from the ACF. Other fixes:
- Windowing is now a pipeline filter function
- BUG: RMS slope/curvature calculation with a cutoff requires the prior application of a window