### PR TITLE
ENH: NetCDF format for storing and retrieving topographies, including metadata

### DIFF
--- a/SurfaceTopography/HeightContainer.py
+++ b/SurfaceTopography/HeightContainer.py
@@ -85,6 +85,9 @@ class AbstractHeightContainer(object):
     def __dir__(self):
         return sorted(super().__dir__() + [*self._functions])
 
+    def __eq__(self, other):
+        return self._info == other._info
+
     def __getstate__(self):
         """
         Upon pickling, it is called and the returned object is pickled as the
@@ -167,6 +170,9 @@ class DecoratedTopography(AbstractHeightContainer):
         assert isinstance(topography, AbstractHeightContainer)
         self.parent_topography = topography
         self._communicator = self.parent_topography.communicator
+
+    def __eq__(self, other):
+        return super.__eq__(self, other) and self.parent_topography == other.parent_topography
 
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for

--- a/SurfaceTopography/HeightContainer.py
+++ b/SurfaceTopography/HeightContainer.py
@@ -30,6 +30,8 @@ Base class for geometric topogography descriptions
 
 import abc
 
+import numpy as np
+
 from NuMPI import MPI
 
 # Standardized entries for the info dictionary
@@ -86,7 +88,7 @@ class AbstractHeightContainer(object):
         return sorted(super().__dir__() + [*self._functions])
 
     def __eq__(self, other):
-        return self._info == other._info
+        return self.info == other.info and self.is_periodic == other.is_periodic
 
     def __getstate__(self):
         """
@@ -170,9 +172,6 @@ class DecoratedTopography(AbstractHeightContainer):
         assert isinstance(topography, AbstractHeightContainer)
         self.parent_topography = topography
         self._communicator = self.parent_topography.communicator
-
-    def __eq__(self, other):
-        return super.__eq__(self, other) and self.parent_topography == other.parent_topography
 
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
@@ -271,6 +270,9 @@ class UniformTopographyInterface(TopographyInterface, metaclass=abc.ABCMeta):
         except ValueError:
             return p, h
 
+    def __eq__(self, other):
+        return super.__eq__(self, other) and np.allclose(self.positions_and_heights(), other.positions_and_heights())
+
     def __getitem__(self, i):
         return self.heights()[i]
 
@@ -316,6 +318,9 @@ class NonuniformLineScanInterface(TopographyInterface, metaclass=abc.ABCMeta):
     @property
     def is_MPI(self):
         return False
+
+    def __eq__(self, other):
+        return super.__eq__(self, other) and np.allclose(self.positions_and_heights(), other.positions_and_heights())
 
     def __getitem__(self, i):
         return self.positions()[i], self.heights()[i]

--- a/SurfaceTopography/IO/DI.py
+++ b/SurfaceTopography/IO/DI.py
@@ -36,7 +36,7 @@ import numpy as np
 
 from SurfaceTopography import Topography
 
-from .common import get_unit_conversion_factor, height_units, mangle_height_unit
+from .common import get_unit_conversion_factor, height_units, mangle_length_unit_utf8
 from .Reader import ReaderBase, ChannelInfo
 
 
@@ -111,9 +111,7 @@ supports V4.3 and later version of the format.
             for n, p in parameters:
                 if n == 'file list':
                     if 'date' in p:
-                        info['acquisition_time'] = \
-                            datetime.strptime(p['date'],
-                                              '%I:%M:%S %p %a %b %d %Y')
+                        info['acquisition_time'] = str(datetime.strptime(p['date'], '%I:%M:%S %p %a %b %d %Y'))
                 elif n == 'scanner list' or n == 'ciao scan list':
                     scanner.update(p)
                 elif n == 'ciao image list':
@@ -127,7 +125,7 @@ supports V4.3 and later version of the format.
                     sx = float(s[0])
                     sy = float(s[1])
 
-                    xy_unit = mangle_height_unit(s[2])
+                    xy_unit = mangle_length_unit_utf8(s[2])
                     offset = int(p['data offset'])
                     self._offsets.append(offset)
 
@@ -169,7 +167,7 @@ supports V4.3 and later version of the format.
                                                          soft_unit,
                                                          image_data_key))
                     if height_unit in height_units:
-                        height_unit = mangle_height_unit(height_unit)
+                        height_unit = mangle_length_unit_utf8(height_unit)
                         if xy_unit != height_unit:
                             fac = get_unit_conversion_factor(xy_unit,
                                                              height_unit)

--- a/SurfaceTopography/IO/FromFile.py
+++ b/SurfaceTopography/IO/FromFile.py
@@ -114,8 +114,7 @@ def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
             if channel_index is None:
                 channel_index = self._default_channel_index
 
-            if subdomain_locations is not None or \
-                    nb_subdomain_grid_pts is not None:
+            if subdomain_locations is not None or nb_subdomain_grid_pts is not None:
                 raise RuntimeError(
                     'This reader does not support MPI parallelization.')
 
@@ -123,8 +122,7 @@ def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
                 raise RuntimeError('Reader supports only a single channel 0.')
 
             print(physical_sizes, self._topography.physical_sizes)
-            physical_sizes = self._check_physical_sizes(
-                physical_sizes, self._topography.physical_sizes)
+            physical_sizes = self._check_physical_sizes(physical_sizes, self._topography.physical_sizes)
             print(physical_sizes)
 
             # Rewind to position where the data is. Otherwise this method

--- a/SurfaceTopography/IO/FromFile.py
+++ b/SurfaceTopography/IO/FromFile.py
@@ -121,9 +121,7 @@ def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
             if channel_index != 0:
                 raise RuntimeError('Reader supports only a single channel 0.')
 
-            print(physical_sizes, self._topography.physical_sizes)
             physical_sizes = self._check_physical_sizes(physical_sizes, self._topography.physical_sizes)
-            print(physical_sizes)
 
             # Rewind to position where the data is. Otherwise this method
             # cannot be called twice.

--- a/SurfaceTopography/IO/FromFile.py
+++ b/SurfaceTopography/IO/FromFile.py
@@ -122,10 +122,18 @@ def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
             if channel_index != 0:
                 raise RuntimeError('Reader supports only a single channel 0.')
 
+            print(physical_sizes, self._topography.physical_sizes)
+            physical_sizes = self._check_physical_sizes(
+                physical_sizes, self._topography.physical_sizes)
+            print(physical_sizes)
+
             # Rewind to position where the data is. Otherwise this method
             # cannot be called twice.
             if hasattr(self._fobj, 'seek'):
                 self._fobj.seek(self._file_position)
+
+            # Read again, but this time with physical_sizes set (if not
+            # specified in file)
             return reader_func(self._fobj, physical_sizes=physical_sizes,
                                height_scale_factor=height_scale_factor,
                                info=info.copy(), periodic=periodic)

--- a/SurfaceTopography/IO/MI.py
+++ b/SurfaceTopography/IO/MI.py
@@ -28,7 +28,7 @@
 import numpy as np
 
 from .. import Topography
-from .common import OpenFromAny, mangle_height_unit
+from .common import OpenFromAny, mangle_length_unit_utf8
 from .Reader import ReaderBase, CorruptFile, ChannelInfo
 
 image_head = b'fileType      Image\n'
@@ -105,7 +105,7 @@ topography map as well as its units.
             # Reformat the metadata
             for buf in self.mifile.channels:
                 buf.meta['name'] = buf.name
-                buf.meta['unit'] = mangle_height_unit(
+                buf.meta['unit'] = mangle_length_unit_utf8(
                     buf.meta.pop('bufferUnit'))
                 buf.meta['range'] = buf.meta.pop('bufferRange')
                 buf.meta['label'] = buf.meta.pop('bufferLabel')

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -158,7 +158,7 @@ plt.show()
             else:
                 # ...and it is 1D (a line scan)
                 try:
-                    self._physical_sizes = (self._x_var.length)
+                    self._physical_sizes = (self._x_var.length,)
                 except AttributeError:
                     pass
 

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -310,7 +310,8 @@ def write_nc_uniform(topography, filename, format='NETCDF3_64BIT_OFFSET'):
             del info['unit']
         except KeyError:
             pass
-        nc.json = json.dumps(info, ensure_ascii=True, cls=NumpyEncoder)
+        if info != {}:
+            nc.json = json.dumps(info, ensure_ascii=True, cls=NumpyEncoder)
 
         # Create dimensions and heights variable
         try:
@@ -385,7 +386,8 @@ def write_nc_nonuniform(line_scan, filename, format='NETCDF3_64BIT_OFFSET'):
             del info['unit']
         except KeyError:
             pass
-        nc.json = json.dumps(info)
+        if info != {}:
+            nc.json = json.dumps(info)
 
         nx, = line_scan.nb_grid_pts
 

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -78,7 +78,7 @@ variables:
         y:periodic = 1 ;
         y:unit = "um" ;
     double heights(x, y) ;
-    	heights:unit = "um" ;
+        heights:unit = "um" ;
 }
 ```
 The following code snippets reads the file and displays the topography data as

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -343,9 +343,10 @@ def write_nc_uniform(topography, filename, format='NETCDF3_64BIT_OFFSET'):
             if 'unit' in topography.info:
                 # scipy.io.netcdf_file does not support UTF-8
                 x_var.unit = mangle_length_unit_ascii(topography.info['unit'])
-            x_var[...] = x[:, 0]
 
             if topography.dim > 1:
+                x_var[...] = x[:, 0]
+
                 y_var = nc.createVariable('y', 'f8', ('y',))
 
                 y_var.length = sy
@@ -354,6 +355,8 @@ def write_nc_uniform(topography, filename, format='NETCDF3_64BIT_OFFSET'):
                     # scipy.io.netcdf_file does not support UTF-8
                     y_var.unit = mangle_length_unit_ascii(topography.info['unit'])
                 y_var[...] = y[0, :]
+            else:
+                x_var[...] = x
 
         if topography.is_domain_decomposed:
             heights_var.set_collective(True)

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -253,10 +253,12 @@ plt.show()
                 if physical_sizes is not None:
                     raise ValueError('You cannot specify physical sizes for a nonuniform topography.')
 
+                if self._periodic:
+                    raise ValueError('NetCDF file indicates periodicity, but this is a nonuniform line scan which '
+                                     'cannot be periodic.')
+
                 # This is a nonuniform line scan
-                return NonuniformLineScan(np.array(self._x_var[...]), np.array(self._heights_var[...]),
-                                          periodic=self._periodic if periodic is None else periodic,
-                                          info=_info)
+                return NonuniformLineScan(np.array(self._x_var[...]), np.array(self._heights_var[...]), info=_info)
         else:
             if self._y_dim is None:
                 raise ValueError('Parallel reading only works for topographies, not line scans.')

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -35,7 +35,6 @@ from ..HeightContainer import UniformTopographyInterface, NonuniformLineScanInte
 
 from .Reader import ReaderBase, ChannelInfo
 
-
 format_to_scipy_version = {
     'NETCDF3_CLASSIC': 1,
     'NETCDF3_64BIT_OFFSET': 2
@@ -345,7 +344,7 @@ def write_nc_uniform(topography, filename, format='NETCDF3_64BIT_OFFSET'):
                 x_var.unit = mangle_length_unit_ascii(topography.info['unit'])
 
             if topography.dim > 1:
-                x_var[...] = x[:, 0]
+                x_var[...] = np.arange(nx) / nx * sx
 
                 y_var = nc.createVariable('y', 'f8', ('y',))
 
@@ -354,9 +353,7 @@ def write_nc_uniform(topography, filename, format='NETCDF3_64BIT_OFFSET'):
                 if 'unit' in topography.info:
                     # scipy.io.netcdf_file does not support UTF-8
                     y_var.unit = mangle_length_unit_ascii(topography.info['unit'])
-                y_var[...] = y[0, :]
-            else:
-                x_var[...] = x
+                y_var[...] = np.arange(ny) / ny * sy
 
         if topography.is_domain_decomposed:
             heights_var.set_collective(True)

--- a/SurfaceTopography/IO/OPDx.py
+++ b/SurfaceTopography/IO/OPDx.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 import numpy as np
 
 from .. import Topography
-from .common import OpenFromAny, get_unit_conversion_factor, mangle_height_unit
+from .common import OpenFromAny, get_unit_conversion_factor, mangle_length_unit_utf8
 from .Reader import ReaderBase, ChannelInfo
 
 MAGIC = "VCA DATA\x01\x00\x00\x55"
@@ -124,13 +124,13 @@ File format of the Bruker Dektak XT* series stylus profilometer.
                 # find out physical sizes in a  common unit
                 # without touching the meta data, scale heights accordingly
                 #
-                unit_x = mangle_height_unit(metadata['Width_unit'])
+                unit_x = mangle_length_unit_utf8(metadata['Width_unit'])
                 size_x = metadata['Width_value']
 
-                unit_y = mangle_height_unit(metadata['Height_unit'])
+                unit_y = mangle_length_unit_utf8(metadata['Height_unit'])
                 size_y = metadata['Height_value']
 
-                unit_z = mangle_height_unit(metadata['z_unit'])
+                unit_z = mangle_length_unit_utf8(metadata['z_unit'])
 
                 # we want value in unit_x units
                 unit_factor_y = get_unit_conversion_factor(unit_y,

--- a/SurfaceTopography/IO/Reader.py
+++ b/SurfaceTopography/IO/Reader.py
@@ -297,11 +297,7 @@ class ReaderBase(metaclass=abc.ABCMeta):
     @classmethod
     def _check_physical_sizes(self, physical_sizes_from_arg,
                               physical_sizes=None):
-        if physical_sizes is None:
-            if physical_sizes_from_arg is None:
-                raise ValueError("physical_sizes could not be extracted from "
-                                 "file, you should provide it")
-        else:
+        if physical_sizes is not None:
             if physical_sizes_from_arg is None:
                 physical_sizes_from_arg = physical_sizes
             elif tuple(physical_sizes_from_arg) != tuple(physical_sizes):

--- a/SurfaceTopography/IO/Reader.py
+++ b/SurfaceTopography/IO/Reader.py
@@ -297,10 +297,15 @@ class ReaderBase(metaclass=abc.ABCMeta):
     @classmethod
     def _check_physical_sizes(self, physical_sizes_from_arg,
                               physical_sizes=None):
-        if physical_sizes is not None:
+        """Handle overriding of `physical_sizes` arguments and make sure,
+        that return value is not `None`."""
+        if physical_sizes is None:
+            if physical_sizes_from_arg is None:
+                raise ValueError("`physical_sizes` could not be extracted from file, you must provide it.")
+        else:
             if physical_sizes_from_arg is None:
                 physical_sizes_from_arg = physical_sizes
-            elif tuple(physical_sizes_from_arg) != tuple(physical_sizes):
+            if tuple(physical_sizes_from_arg) != tuple(physical_sizes):
                 warnings.warn(
                     "A physical size different from the value specified when "
                     "calling the reader was present in the file. We will "

--- a/SurfaceTopography/IO/Text.py
+++ b/SurfaceTopography/IO/Text.py
@@ -292,8 +292,6 @@ def read_xyz(fobj, physical_sizes=None, height_scale_factor=None, info={},
     ----------
     fobj : str or file object
          File name or stream.
-    unit : str
-         Physical unit.
     tol : float
          Tolerance for detecting uniform grids
 
@@ -314,10 +312,12 @@ def read_xyz(fobj, physical_sizes=None, height_scale_factor=None, info={},
         if np.max(np.abs(np.diff(x) - d_uniform)) < tol:
             if physical_sizes is None:
                 physical_sizes = d_uniform * len(x)
-            t = UniformLineScan(z, physical_sizes, info=info,
-                                periodic=periodic)
+            t = UniformLineScan(z, physical_sizes, info=info, periodic=periodic)
         else:
-            t = NonuniformLineScan(x, z, info=info, periodic=periodic)
+            if periodic:
+                raise ValueError('XYZ reader found nonuniform data, and the user specified that it is periodic. '
+                                 'Nonuniform line scans cannot be periodic.')
+            t = NonuniformLineScan(x, z, info=info)
             if physical_sizes is not None:
                 if not np.allclose(t.physical_sizes, physical_sizes):
                     raise ValueError(

--- a/SurfaceTopography/IO/Text.py
+++ b/SurfaceTopography/IO/Text.py
@@ -317,12 +317,13 @@ def read_xyz(fobj, physical_sizes=None, height_scale_factor=None, info={},
             t = UniformLineScan(z, physical_sizes, info=info,
                                 periodic=periodic)
         else:
-            if physical_sizes is not None:
-                raise ValueError(
-                    'XYZ reader found nonuniform data. Manually setting the'
-                    'physical size is not possible for this type of data.')
-
             t = NonuniformLineScan(x, z, info=info, periodic=periodic)
+            if physical_sizes is not None:
+                if not np.allclose(t.physical_sizes, physical_sizes):
+                    raise ValueError(
+                        'XYZ reader found nonuniform data. Manually setting the '
+                        'physical size is not possible for this type of data.')
+
     elif len(data) == 3:
         # This is a topography map.
         x, y, z = data

--- a/SurfaceTopography/IO/Text.py
+++ b/SurfaceTopography/IO/Text.py
@@ -26,7 +26,7 @@ import re
 
 import numpy as np
 
-from .common import CHANNEL_NAME_INFO_KEY, height_units, mangle_height_unit, text
+from .common import CHANNEL_NAME_INFO_KEY, height_units, mangle_length_unit_utf8, text
 from .FromFile import make_wrapped_reader
 from ..HeightContainer import UniformTopographyInterface
 from ..NonuniformLineScan import NonuniformLineScan
@@ -144,24 +144,24 @@ def read_asc(fobj, physical_sizes=None, height_scale_factor=None, x_factor=1.0,
                 xsiz = float(match.group('value'))
                 x = match.group('unit')
                 if x:
-                    xunit = mangle_height_unit(x)
+                    xunit = mangle_length_unit_utf8(x)
             elif key == 'ysiz':
                 ysiz = float(match.group('value'))
                 y = match.group('unit')
                 if y:
-                    yunit = mangle_height_unit(y)
+                    yunit = mangle_length_unit_utf8(y)
             elif key == 'xunit':
-                xunit = mangle_height_unit(match.group(1))
+                xunit = mangle_length_unit_utf8(match.group(1))
             elif key == 'yunit':
-                yunit = mangle_height_unit(match.group(1))
+                yunit = mangle_length_unit_utf8(match.group(1))
             elif key == 'zunit':
-                zunit = mangle_height_unit(match.group(1))
+                zunit = mangle_length_unit_utf8(match.group(1))
             elif key == 'xfac':
                 xfac = float(match.group('value'))
-                xunit = mangle_height_unit(match.group('unit'))
+                xunit = mangle_length_unit_utf8(match.group('unit'))
             elif key == 'zfac':
                 zfac = float(match.group('value'))
-                zunit = mangle_height_unit(match.group('unit'))
+                zunit = mangle_length_unit_utf8(match.group('unit'))
             elif key == 'channel_name':
                 channel_name = match.group(1).strip()
 

--- a/SurfaceTopography/IO/common.py
+++ b/SurfaceTopography/IO/common.py
@@ -58,7 +58,7 @@ def get_unit_conversion_factor(unit1_str, unit2_str):
     return unit_scales[unit1_str] / unit_scales[unit2_str]
 
 
-def mangle_height_unit(unit):
+def mangle_length_unit_utf8(unit):
     if isinstance(unit, str):
         unit = unit.strip()
     else:
@@ -73,7 +73,7 @@ def mangle_height_unit(unit):
         return unit
 
 
-def no_uft8_height_unit(unit):
+def mangle_length_unit_ascii(unit):
     unit = unit.strip()
     if unit == '':
         return None

--- a/SurfaceTopography/NonuniformLineScan.py
+++ b/SurfaceTopography/NonuniformLineScan.py
@@ -46,10 +46,6 @@ class NonuniformLineScan(AbstractHeightContainer, NonuniformLineScanInterface):
         self._h = np.asarray(y)
         self._periodic = periodic
 
-    def __eq__(self, other):
-        return super.__eq__(self, other) and np.allclose(self._x, other._x) and \
-               np.allclose(self._h, other._h) and self._periodic == other._periodic
-
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
             the instance

--- a/SurfaceTopography/NonuniformLineScan.py
+++ b/SurfaceTopography/NonuniformLineScan.py
@@ -40,17 +40,16 @@ class NonuniformLineScan(AbstractHeightContainer, NonuniformLineScanInterface):
     Nonuniform topography with point list consisting of static numpy arrays.
     """
 
-    def __init__(self, x, y, info={}, periodic=False):
+    def __init__(self, x, y, info={}):
         super().__init__(info=info)
         self._x = np.asarray(x)
         self._h = np.asarray(y)
-        self._periodic = periodic
 
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
             the instance
         """
-        state = super().__getstate__(), self._x, self._h, self._periodic
+        state = super().__getstate__(), self._x, self._h
         return state
 
     def __setstate__(self, state):
@@ -58,7 +57,7 @@ class NonuniformLineScan(AbstractHeightContainer, NonuniformLineScanInterface):
         Keyword Arguments:
         state -- result of __getstate__
         """
-        superstate, self._x, self._h, self._periodic = state
+        superstate, self._x, self._h = state
         super().__setstate__(superstate)
 
     # Implement abstract methods of AbstractHeightContainer
@@ -76,7 +75,7 @@ class NonuniformLineScan(AbstractHeightContainer, NonuniformLineScanInterface):
     def is_periodic(self):
         """Return whether the topography is periodically repeated at the
         boundaries."""
-        return self._periodic
+        return False
 
     @property
     def is_uniform(self):

--- a/SurfaceTopography/NonuniformLineScan.py
+++ b/SurfaceTopography/NonuniformLineScan.py
@@ -46,6 +46,10 @@ class NonuniformLineScan(AbstractHeightContainer, NonuniformLineScanInterface):
         self._h = np.asarray(y)
         self._periodic = periodic
 
+    def __eq__(self, other):
+        return super.__eq__(self, other) and np.allclose(self._x, other._x) and \
+               np.allclose(self._h, other._h) and self._periodic == other._periodic
+
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
             the instance

--- a/SurfaceTopography/UniformLineScanAndTopography.py
+++ b/SurfaceTopography/UniformLineScanAndTopography.py
@@ -295,8 +295,7 @@ class Topography(AbstractHeightContainer, UniformTopographyInterface):
 
     def __eq__(self, other):
         return super.__eq__(self, other) and np.allclose(self._heights, other._heights) and \
-               self._size == other._size and self._periodic == other._periodic and \
-               self._subdomain_locations == other._subdomain_locations and self._nb_grid_pts == other._nb_grid_pts
+               self._size == other._size and self._periodic == other._periodic
 
     def __getstate__(self):
         state = super().__getstate__(), self._heights, self._size, self._periodic, self._subdomain_locations, \
@@ -474,9 +473,6 @@ class ScaledUniformTopography(DecoratedUniformTopography):
         super().__init__(topography, info=info)
         self._scale_factor = float(scale_factor)
 
-    def __eq__(self, other):
-        return super.__eq__(self, other) and self._scale_factor == other._scale_factor
-
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
             the instance
@@ -595,10 +591,6 @@ class DetrendedUniformTopography(DecoratedUniformTopography):
                 raise ValueError(
                     "Unsupported detrend mode '{}' for 2D topographies."
                     .format(self._detrend_mode))
-
-    def __eq__(self, other):
-        return super.__eq__(self, other) and self._detrend_mode == other._detrend_mode and \
-               self._coeffs == other._coeffs
 
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for

--- a/SurfaceTopography/UniformLineScanAndTopography.py
+++ b/SurfaceTopography/UniformLineScanAndTopography.py
@@ -72,10 +72,6 @@ class UniformLineScan(AbstractHeightContainer, UniformTopographyInterface):
         self._size = np.asarray(physical_sizes).item()
         self._periodic = periodic
 
-    def __eq__(self, other):
-        return super.__eq__(self, other) and np.allclose(self._heights, other._heights) and \
-               np.allclose(self._size, other._size) and self._periodic == other._periodic
-
     def __getstate__(self):
         state = super().__getstate__(), self._heights, self._size, self._periodic
         return state
@@ -292,10 +288,6 @@ class Topography(AbstractHeightContainer, UniformTopographyInterface):
 
         self._size = physical_sizes
         self._periodic = periodic
-
-    def __eq__(self, other):
-        return super.__eq__(self, other) and np.allclose(self._heights, other._heights) and \
-               self._size == other._size and self._periodic == other._periodic
 
     def __getstate__(self):
         state = super().__getstate__(), self._heights, self._size, self._periodic, self._subdomain_locations, \

--- a/SurfaceTopography/UniformLineScanAndTopography.py
+++ b/SurfaceTopography/UniformLineScanAndTopography.py
@@ -72,9 +72,12 @@ class UniformLineScan(AbstractHeightContainer, UniformTopographyInterface):
         self._size = np.asarray(physical_sizes).item()
         self._periodic = periodic
 
+    def __eq__(self, other):
+        return super.__eq__(self, other) and np.allclose(self._heights, other._heights) and \
+               np.allclose(self._size, other._size) and self._periodic == other._periodic
+
     def __getstate__(self):
-        state = super().__getstate__(), self._heights, self._size, \
-                self._periodic
+        state = super().__getstate__(), self._heights, self._size, self._periodic
         return state
 
     def __setstate__(self, state):
@@ -290,9 +293,14 @@ class Topography(AbstractHeightContainer, UniformTopographyInterface):
         self._size = physical_sizes
         self._periodic = periodic
 
+    def __eq__(self, other):
+        return super.__eq__(self, other) and np.allclose(self._heights, other._heights) and \
+               self._size == other._size and self._periodic == other._periodic and \
+               self._subdomain_locations == other._subdomain_locations and self._nb_grid_pts == other._nb_grid_pts
+
     def __getstate__(self):
-        state = super().__getstate__(), self._heights, self._size, \
-                self._periodic, self._subdomain_locations, self._nb_grid_pts
+        state = super().__getstate__(), self._heights, self._size, self._periodic, self._subdomain_locations, \
+                self._nb_grid_pts
         return state
 
     def __setstate__(self, state):
@@ -466,6 +474,9 @@ class ScaledUniformTopography(DecoratedUniformTopography):
         super().__init__(topography, info=info)
         self._scale_factor = float(scale_factor)
 
+    def __eq__(self, other):
+        return super.__eq__(self, other) and self._scale_factor == other._scale_factor
+
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for
             the instance
@@ -584,6 +595,10 @@ class DetrendedUniformTopography(DecoratedUniformTopography):
                 raise ValueError(
                     "Unsupported detrend mode '{}' for 2D topographies."
                     .format(self._detrend_mode))
+
+    def __eq__(self, other):
+        return super.__eq__(self, other) and self._detrend_mode == other._detrend_mode and \
+               self._coeffs == other._coeffs
 
     def __getstate__(self):
         """ is called and the returned object is pickled as the contents for

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ setuptools_scm>=3.5.0
 muFFT>=0.12.0
 runtests>=0.0.28
 defusedxml
+numpyencoder

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
         'netCDF4>=1.5.0',
         'igor',
         'h5py',
-        'defusedxml'
+        'defusedxml',
+        'numpyencoder'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ setup(
         'numpy>=1.11.0',
         'NuMPI>=0.1.4',
         'muFFT>=0.12.0',
-        'netCDF4>=1.5.0',
         'igor',
         'h5py',
         'defusedxml',

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -326,7 +326,6 @@ class IOTest(unittest.TestCase):
                 self.assertEqual(t, t2)
 
 
-
 class UnknownFileFormatGivenTest(unittest.TestCase):
 
     def test_read(self):

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -313,7 +313,7 @@ class IOTest(unittest.TestCase):
                     assert channel.physical_sizes == topography.physical_sizes
 
     def test_nb_grid_pts_and_physical_sizes_are_tuples_or_none(self):
-        file_list = self.text_example_file_list + self.binary_example_file_list
+        file_list = text_example_file_list + binary_example_file_list
 
         for fn in file_list:
             r = open_topography(fn)

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -107,6 +107,11 @@ text_example_file_list = _convert_filelist([
     # 'example6.txt',
 ])
 
+explicit_physical_sizes = _convert_filelist([
+    'example5.txt',
+    'example1.mat',
+    'example-2d.npy'
+])
 
 @pytest.mark.parametrize("reader", readers)
 def test_closes_file_on_failure(reader):
@@ -331,7 +336,10 @@ class IOTest(unittest.TestCase):
 def test_to_netcdf(fn):
     """Test that files can be stored as NetCDF and that reading then gives
     an identical topography object"""
-    t = read_topography(fn)
+    if fn in explicit_physical_sizes:
+        t = read_topography(fn, physical_sizes=(1, 1))
+    else:
+        t = read_topography(fn)
     with tempfile.TemporaryDirectory() as d:
         tmpfn = f'{d}/netcdf_representation.nc'
         t.to_netcdf(tmpfn)

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -56,6 +56,58 @@ DATADIR = os.path.join(
     'file_format_examples')
 
 
+def _convert_filelist(filelist):
+    """
+    Parameters
+    ----------
+    filelist
+        list of strings with filenames withput path
+
+    Returns
+    -------
+    List of filenames prepended with DATADIR
+    """
+    return [os.path.join(DATADIR, fn) for fn in filelist]
+
+
+binary_example_file_list = _convert_filelist([
+    'di1.di',
+    'di2.di',
+    'di3.di',
+    'di4.di',
+    'example.ibw',
+    'spot_1-1000nm.ibw',
+    # 'surface.2048x2048.h5',
+    '10x10-one_channel_without_name.ibw',
+    'example1.mat',
+    'example.opd',
+    'example.x3p',
+    'example2.x3p',
+    'opdx1.OPDx',
+    'opdx2.OPDx',
+    'mi1.mi',
+    'N46E013.hgt',
+    'example-2d.npy',
+    'example.zon',
+])
+
+text_example_file_list = _convert_filelist([
+    'example.asc',
+    'example1.txt',
+    'example2.txt',
+    'example3.txt',
+    'example4.txt',
+    'example5.txt',
+    'example8.txt',
+    # example8: from the reader's docstring, with extra newline at end
+    'line_scan_1_minimal_spaces.asc',
+    'opdx1.txt',
+    'opdx2.txt',
+    # Not yet working
+    # 'example6.txt',
+])
+
+
 @pytest.mark.parametrize("reader", readers)
 def test_closes_file_on_failure(reader):
     """
@@ -87,61 +139,7 @@ def test_cannot_detect_file_format_on_txt():
 
 
 class IOTest(unittest.TestCase):
-
-    @staticmethod
-    def _convert_filelist(filelist):
-        """
-        Parameters
-        ----------
-        filelist
-            list of strings with filenames withput path
-
-        Returns
-        -------
-        List of filenames prepended with DATADIR
-        """
-        return [os.path.join(DATADIR, fn) for fn in filelist]
-
     def setUp(self):
-        binary_examples = [
-            'di1.di',
-            'di2.di',
-            'di3.di',
-            'di4.di',
-            'example.ibw',
-            'spot_1-1000nm.ibw',
-            # 'surface.2048x2048.h5',
-            '10x10-one_channel_without_name.ibw',
-            'example1.mat',
-            'example.opd',
-            'example.x3p',
-            'example2.x3p',
-            'opdx1.OPDx',
-            'opdx2.OPDx',
-            'mi1.mi',
-            'N46E013.hgt',
-            'example-2d.npy',
-            'example.zon',
-        ]
-
-        text_examples = [
-            'example.asc',
-            'example1.txt',
-            'example2.txt',
-            'example3.txt',
-            'example4.txt',
-            'example5.txt',
-            'example8.txt',
-            # example8: from the reader's docstring, with extra newline at end
-            'line_scan_1_minimal_spaces.asc',
-            'opdx1.txt',
-            'opdx2.txt',
-            # Not yet working
-            # 'example6.txt',
-        ]
-
-        self.binary_example_file_list = self._convert_filelist(binary_examples)
-        self.text_example_file_list = self._convert_filelist(text_examples)
         self.text_example_memory_list = [
             """
             0 0
@@ -152,7 +150,7 @@ class IOTest(unittest.TestCase):
         ]
 
     def test_keep_file_open(self):
-        for fn in self.text_example_file_list:
+        for fn in text_example_file_list:
             # Text file can be opened as binary or text
             with open(fn, 'rb') as f:
                 open_topography(f)
@@ -160,7 +158,7 @@ class IOTest(unittest.TestCase):
             with open(fn, 'r') as f:
                 open_topography(f)
                 self.assertFalse(f.closed, msg=fn)
-        for fn in self.binary_example_file_list:
+        for fn in binary_example_file_list:
             with open(fn, 'rb') as f:
                 open_topography(f)
                 self.assertFalse(f.closed, msg=fn)
@@ -182,7 +180,7 @@ class IOTest(unittest.TestCase):
     def test_is_binary_stream(self):
 
         # just grep a random existing file here
-        fn = self.text_example_file_list[0]
+        fn = text_example_file_list[0]
 
         self.assertTrue(is_binary_stream(open(fn, mode='rb')))
         self.assertFalse(
@@ -195,7 +193,7 @@ class IOTest(unittest.TestCase):
             is_binary_stream(io.StringIO("11111")))  # some bytes in memory
 
     def test_can_be_pickled(self):
-        file_list = self.text_example_file_list + self.binary_example_file_list
+        file_list = text_example_file_list + binary_example_file_list
 
         for fn in file_list:
             reader = open_topography(fn)
@@ -230,7 +228,7 @@ class IOTest(unittest.TestCase):
                         assert_array_equal(x.heights(), y.heights())
 
     def test_periodic_flag(self):
-        file_list = self.text_example_file_list + self.binary_example_file_list
+        file_list = text_example_file_list + binary_example_file_list
         for fn in file_list:
             reader = open_topography(fn)
             physical_sizes = None
@@ -250,7 +248,7 @@ class IOTest(unittest.TestCase):
         height_scale_factor arguments. Also check whether we can execute
         `topography` multiple times for all readers"""
         physical_sizes0 = (1.2, 1.3)
-        for fn in self.text_example_file_list + self.binary_example_file_list:
+        for fn in text_example_file_list + binary_example_file_list:
             # Test open -> topography
             r = open_topography(fn)
             physical_sizes = None if r.channels[0].dim == 1 \
@@ -277,7 +275,7 @@ class IOTest(unittest.TestCase):
         height_scale_factor arguments. Also check whether we can execute
         `topography` multiple times for all readers"""
         physical_sizes0 = (1.2, 1.3)
-        for fn in self.text_example_file_list + self.binary_example_file_list:
+        for fn in text_example_file_list + binary_example_file_list:
             # Test open -> topography
             r = open_topography(open(fn, mode='rb'))
             physical_sizes = None if r.channels[0].dim == 1 \
@@ -299,7 +297,7 @@ class IOTest(unittest.TestCase):
         the  same in the ChannelInfo and the loaded topography
         """
 
-        for fn in self.text_example_file_list + self.binary_example_file_list:
+        for fn in text_example_file_list + binary_example_file_list:
             reader = open_topography(fn)
 
             for channel in reader.channels:
@@ -314,16 +312,17 @@ class IOTest(unittest.TestCase):
                 if channel.physical_sizes is not None:
                     assert channel.physical_sizes == topography.physical_sizes
 
-    def test_to_netcdf(self):
-        """Test that files can be stored as NetCDF and that reading then gives
-        an identical topography object"""
-        for fn in self.text_example_file_list + self.binary_example_file_list:
-            t = read_topography(fn)
-            with tempfile.TemporaryDirectory() as d:
-                tmpfn = f'{d}/netcdf_representation.nc'
-                t.to_netcdf(tmpfn)
-                t2 = read_topography(tmpfn)
-                self.assertEqual(t, t2)
+
+@pytest.mark.parametrize('fn', text_example_file_list + binary_example_file_list)
+def test_to_netcdf(fn):
+    """Test that files can be stored as NetCDF and that reading then gives
+    an identical topography object"""
+    t = read_topography(fn)
+    with tempfile.TemporaryDirectory() as d:
+        tmpfn = f'{d}/netcdf_representation.nc'
+        t.to_netcdf(tmpfn)
+        t2 = read_topography(tmpfn)
+        assert t == t2
 
 
 class UnknownFileFormatGivenTest(unittest.TestCase):
@@ -371,8 +370,7 @@ def test_readers_have_name(reader):
 
 def test_di_date():
     t = read_topography(os.path.join(DATADIR, 'di1.di'))
-    assert t.info['acquisition_time'] == datetime.datetime(2016, 1, 12, 9, 57,
-                                                           48)
+    assert t.info['acquisition_time'] == str(datetime.datetime(2016, 1, 12, 9, 57, 48))
 
 
 # yes, the German version still has "Value units"

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -169,8 +169,7 @@ class IOTest(unittest.TestCase):
                 open_topography(f)
                 self.assertFalse(
                     f.closed,
-                    msg="text memory stream for '{}' was closed".format(
-                        datastr))
+                    msg="text memory stream for '{}' was closed".format(datastr))
 
             # Doing the same when but only giving a binary stream
             with io.BytesIO(datastr.encode(encoding='utf-8')) as f:
@@ -314,6 +313,18 @@ class IOTest(unittest.TestCase):
 
                 if channel.physical_sizes is not None:
                     assert channel.physical_sizes == topography.physical_sizes
+
+    def test_to_netcdf(self):
+        """Test that files can be stored as NetCDF and that reading then gives
+        an identical topography object"""
+        for fn in self.text_example_file_list + self.binary_example_file_list:
+            t = read_topography(fn)
+            with tempfile.TemporaryDirectory() as d:
+                tmpfn = f'{d}/netcdf_representation.nc'
+                t.to_netcdf(tmpfn)
+                t2 = read_topography(tmpfn)
+                self.assertEqual(t, t2)
+
 
 
 class UnknownFileFormatGivenTest(unittest.TestCase):

--- a/test/IO/test_netcdf.py
+++ b/test/IO/test_netcdf.py
@@ -130,7 +130,7 @@ def test_load_no_physical_sizes(comm_self):
     os.remove('no_physical_sizes.nc')
 
 
-def test_save_and_load_line_scan(comm):
+def test_save_and_load_line_scan(comm_self):
     nb_grid_pts = (128,)
     size = (3,)
 

--- a/test/IO/test_netcdf.py
+++ b/test/IO/test_netcdf.py
@@ -24,6 +24,7 @@
 #
 
 import os
+import tempfile
 
 import numpy as np
 from scipy.io.netcdf import netcdf_file
@@ -127,6 +128,26 @@ def test_load_no_physical_sizes(comm_self):
     np.testing.assert_array_almost_equal(t.heights(), t2.heights())
 
     os.remove('no_physical_sizes.nc')
+
+
+def test_save_and_load_line_scan(comm):
+    nb_grid_pts = (128,)
+    size = (3,)
+
+    np.random.seed(1)
+    t = fourier_synthesis(nb_grid_pts, size, 0.8, rms_slope=0.1)
+    t.info['unit'] = 'µm'
+
+    with tempfile.TemporaryDirectory() as d:
+        tmpfn = f'{d}/line_scan.nc'
+
+        # Save file
+        t.to_netcdf(tmpfn)
+
+        # Read file
+        t2 = read_topography(tmpfn)
+
+        assert t == t2
 
 
 if __name__ == '__main__':

--- a/test/test_topography.py
+++ b/test/test_topography.py
@@ -423,7 +423,7 @@ class NumpyAscSurfaceTest(unittest.TestCase):
     def test_example6(self):
         topography_file = open_topography(
             os.path.join(DATADIR, 'example6.txt'))
-        surf = topography_file.topography()
+        surf = topography_file.topography(physical_sizes=(1,))
         self.assertTrue(isinstance(surf, UniformLineScan))
         np.testing.assert_allclose(surf.heights(), [1, 2, 3, 4, 5, 6, 7, 8, 9])
 


### PR DESCRIPTION
This PR implements reading and writing of topographies into NetCDF files - also for line scans. We should be able to use this for caching, i.e. the topography object needs to be restored exactly as it was. (This only works if there is no pipeline attached to it.)