### PR TITLE
Fixing missing attributes for topographies and line scans

### DIFF
--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -5,8 +5,11 @@ Change log for SurfaceTopography
 v0.94.0 (not published yet)
 ---------------------------
 
+- ENH: Added API tests for checking existence of functions
+  and properties for different kinds of topographies (#100)
+- BUG: Fixes missing function for RMS curvature for uniform
+  line scans (#95)
 - BUG: Fixes loading of 2D measurements from xyz data (#93)
-
 
 v0.93.0 (27Apr21)
 -----------------

--- a/SurfaceTopography/NonuniformLineScan.py
+++ b/SurfaceTopography/NonuniformLineScan.py
@@ -100,6 +100,7 @@ class NonuniformLineScan(AbstractTopography, NonuniformLineScanInterface):
     def squeeze(self):
         return self
 
+
 class DecoratedNonuniformTopography(DecoratedTopography,
                                     NonuniformLineScanInterface):
     @property

--- a/SurfaceTopography/NonuniformLineScan.py
+++ b/SurfaceTopography/NonuniformLineScan.py
@@ -97,6 +97,8 @@ class NonuniformLineScan(AbstractTopography, NonuniformLineScanInterface):
     def heights(self):
         return self._h
 
+    def squeeze(self):
+        return self
 
 class DecoratedNonuniformTopography(DecoratedTopography,
                                     NonuniformLineScanInterface):

--- a/SurfaceTopography/Uniform/Filtering.py
+++ b/SurfaceTopography/Uniform/Filtering.py
@@ -425,9 +425,7 @@ class LongCutTopography(FilteredUniformTopography):
         super().__setstate__(superstate)
 
 
-UniformTopographyInterface.register_function("window",
-                                             WindowedUniformTopography)
-UniformTopographyInterface.register_function("filter",
-                                             FilteredUniformTopography)
+UniformTopographyInterface.register_function("window", WindowedUniformTopography)
+UniformTopographyInterface.register_function("filter", FilteredUniformTopography)
 UniformTopographyInterface.register_function("shortcut", ShortCutTopography)
 UniformTopographyInterface.register_function("longcut", LongCutTopography)

--- a/SurfaceTopography/Uniform/Interpolation.py
+++ b/SurfaceTopography/Uniform/Interpolation.py
@@ -195,8 +195,6 @@ class MirrorStichedTopography(DecoratedUniformTopography):
             indexing='ij')
 
 
-Topography.register_function("mirror_stitch",
-                             MirrorStichedTopography)
+Topography.register_function("mirror_stitch", MirrorStichedTopography)
 Topography.register_function("interpolate_bicubic", bicubic_interpolator)
-UniformTopographyInterface.register_function('interpolate_fourier',
-                                             interpolate_fourier)
+UniformTopographyInterface.register_function('interpolate_fourier', interpolate_fourier)

--- a/SurfaceTopography/Uniform/ScalarParameters.py
+++ b/SurfaceTopography/Uniform/ScalarParameters.py
@@ -76,17 +76,23 @@ def rms_height_from_area(topography):
     rms_height : float
         Root mean square height value.
     """
-    n = np.prod(topography.nb_grid_pts)
-    pnp = Reduction(topography._communicator)
-    profile = topography.heights()
-    return np.sqrt(pnp.sum((profile - pnp.sum(profile) / n) ** 2) / n)
+    if topography.dim <= 1:
+        raise ValueError('Areal rms height can only be computed for topographies, not line scans.')
+    elif topography.dim == 2:
+        n = np.prod(topography.nb_grid_pts)
+        pnp = Reduction(topography._communicator)
+        profile = topography.heights()
+        return np.sqrt(pnp.sum((profile - pnp.sum(profile) / n) ** 2) / n)
+    else:
+        raise ValueError(f'Cannot handle topographies of dimension {topography.dim}')
 
 
 def rms_gradient(topography, short_wavelength_cutoff=None, window=None,
                  direction=None):
     """
     Compute the root mean square amplitude of the height gradient of a
-    topography or line scan stored on a uniform grid.
+    topography stored on a uniform grid. The topography must be
+    two-dimensional (i.e. a topography map).
 
     Parameters
     ----------
@@ -129,8 +135,10 @@ def rms_gradient(topography, short_wavelength_cutoff=None, window=None,
 def rms_slope_from_profile(topography, short_wavelength_cutoff=None, window=None,
                            direction=None):
     """
-    Compute the root mean square amplitude of the height gradient of a
-    topography or line scan stored on a uniform grid.
+    Compute the root mean square amplitude of the height derivative of a
+    topography or line scan stored on a uniform grid. If the topography is two
+    dimensional (i.e. a topography map), the derivative is computed in the
+    x-direction.
 
     Parameters
     ----------
@@ -163,17 +171,64 @@ def rms_slope_from_profile(topography, short_wavelength_cutoff=None, window=None
         lambda frequency: frequency[0] ** 2 < 1 / short_wavelength_cutoff ** 2
     if topography.dim == 1:
         dx = topography.derivative(1, mask_function=mask_function)
-    else:
+    elif topography.dim == 2:
         dx, dy = topography.derivative(1, mask_function=mask_function)
+    else:
+        raise ValueError(f'Cannot handle topographies of dimension {topography.dim}')
     return np.sqrt(np.mean(dx ** 2))
+
+
+def rms_curvature_from_profile(topography, short_wavelength_cutoff=None, window=None,
+                               direction=None):
+    """
+    Compute the root mean square amplitude of the second derivative (i.e. the
+    curvature) of a topography or line scan stored on a uniform grid. If the
+    topography is two-dimensional (i.e. a topography map), then the rms curvature
+    is computed only along the x-direction.
+
+    Parameters
+    ----------
+    topography : :obj:`SurfaceTopography` or :obj:`UniformLineScan`
+        SurfaceTopography object containing height information.
+    short_wavelength_cutoff : float
+        All wavelengths below this cutoff will be set to zero amplitude.
+    window : str, optional
+        Window for eliminating edge effect. See scipy.signal.get_window.
+        Only used if short wavelength cutoff is set.
+        (Default: no window for periodic Topographies, "hann" window for
+        nonperiodic Topographies)
+    direction : str, optional
+        Direction in which the window is applied. Possible options are
+        'x', 'y' and 'radial'. If set to None, it chooses 'x' for line
+        scans and 'radial' for topographies. Only used if short wavelength
+        cutoff is set. (Default: None)
+
+    Returns
+    -------
+    rms_curvature : float
+        Root mean square curvature value.
+    """
+    if topography.is_domain_decomposed:
+        raise NotImplementedError("`rms_curvature_from_profile` does not support MPI-decomposed topographies.")
+    if short_wavelength_cutoff is not None:
+        topography = topography.window(window=window, direction=direction)
+    mask_function = None if short_wavelength_cutoff is None else \
+        lambda frequency: frequency[0] ** 2 < 1 / short_wavelength_cutoff ** 2
+    if topography.dim == 1:
+        d2x = topography.derivative(2, mask_function=mask_function)
+    elif topography.dim == 2:
+        d2x, d2y = topography.derivative(2, mask_function=mask_function)
+    else:
+        raise ValueError(f'Cannot handle topographies of dimension {topography.dim}')
+    return np.sqrt(np.mean(d2x ** 2))
 
 
 def rms_laplacian(topography, short_wavelength_cutoff=None, window=None,
                   direction=None):
     """
-    Compute the root mean square Laplacian of the height gradient of a
-    topography or line scan stored on a uniform grid. The rms curvature
-    is half of the value returned here.
+    Compute the root mean square amplitude of the Laplacian (i.e. the sum of
+    second derivatives in x- and y-directions) of a topography on a uniform
+    grid. The topography must be two-dimensional (i.e. a topography map).
 
     Parameters
     ----------
@@ -202,10 +257,7 @@ def rms_laplacian(topography, short_wavelength_cutoff=None, window=None,
     if short_wavelength_cutoff is not None:
         topography = topography.window(window=window, direction=direction)
     if topography.dim == 1:
-        mask_function = None if short_wavelength_cutoff is None else \
-            lambda frequency: frequency[0] ** 2 < 1 / short_wavelength_cutoff ** 2
-        curv = topography.derivative(2, mask_function=mask_function)
-        return np.sqrt((curv ** 2).mean())
+        raise ValueError('RMS Laplacian can only be computed for topographies, not line scans.')
     elif topography.dim == 2:
         mask_function = None if short_wavelength_cutoff is None else \
             lambda frequency: (frequency[0] ** 2 + frequency[1] ** 2) < 1 / short_wavelength_cutoff ** 2
@@ -218,12 +270,10 @@ def rms_laplacian(topography, short_wavelength_cutoff=None, window=None,
 def rms_curvature_from_area(topography, short_wavelength_cutoff=None, window=None,
                             direction=None):
     """
-    Compute the root mean square curvature of the height gradient of a
-    topography or line scan stored on a uniform grid.
-
-    For 2D Data the rms Laplacian is twice of the value returned here.
-
-    For 1D Data they are identical
+    Compute the root mean square amplitude of the curvature of a
+    topography stored on a uniform grid. The topography must be
+    two-dimensional (i.e. a topography map). This function returns
+    half the Laplacian.
 
     Parameters
     ----------
@@ -247,17 +297,8 @@ def rms_curvature_from_area(topography, short_wavelength_cutoff=None, window=Non
     rms_curvature : float
         Root mean square curvature value.
     """
-    if topography.is_domain_decomposed:
-        raise NotImplementedError("`rms_curvature` does not support MPI-decomposed topographies.")
-    if topography.dim == 1:
-        fac = 1.
-    elif topography.dim == 2:
-        fac = 1. / 2
-    else:
-        raise ValueError(f'Cannot handle topographies of dimension {topography.dim}')
-    return fac * rms_laplacian(
-        topography, short_wavelength_cutoff=short_wavelength_cutoff,
-        window=window, direction=direction)
+    return rms_laplacian(topography, short_wavelength_cutoff=short_wavelength_cutoff, window=window,
+                         direction=direction) / 2
 
 
 # Register analysis functions from this module
@@ -265,5 +306,6 @@ UniformTopographyInterface.register_function('rms_height_from_profile', rms_heig
 UniformTopographyInterface.register_function('rms_height_from_area', rms_height_from_area)
 UniformTopographyInterface.register_function('rms_gradient', rms_gradient)
 UniformTopographyInterface.register_function('rms_slope_from_profile', rms_slope_from_profile)
+UniformTopographyInterface.register_function('rms_curvature_from_profile', rms_curvature_from_area)
 UniformTopographyInterface.register_function('rms_laplacian', rms_laplacian)
 UniformTopographyInterface.register_function('rms_curvature_from_area', rms_curvature_from_area)

--- a/SurfaceTopography/Uniform/ScalarParameters.py
+++ b/SurfaceTopography/Uniform/ScalarParameters.py
@@ -306,6 +306,6 @@ UniformTopographyInterface.register_function('rms_height_from_profile', rms_heig
 UniformTopographyInterface.register_function('rms_height_from_area', rms_height_from_area)
 UniformTopographyInterface.register_function('rms_gradient', rms_gradient)
 UniformTopographyInterface.register_function('rms_slope_from_profile', rms_slope_from_profile)
-UniformTopographyInterface.register_function('rms_curvature_from_profile', rms_curvature_from_area)
+UniformTopographyInterface.register_function('rms_curvature_from_profile', rms_curvature_from_profile)
 UniformTopographyInterface.register_function('rms_laplacian', rms_laplacian)
 UniformTopographyInterface.register_function('rms_curvature_from_area', rms_curvature_from_area)

--- a/SurfaceTopography/UniformLineScanAndTopography.py
+++ b/SurfaceTopography/UniformLineScanAndTopography.py
@@ -144,6 +144,9 @@ class UniformLineScan(AbstractTopography, UniformTopographyInterface):
                 fname = fname + ".gz"
         np.savetxt(fname, self.heights())
 
+    def squeeze(self):
+        return self
+
 
 class Topography(AbstractTopography, UniformTopographyInterface):
     """

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,40 +1,180 @@
 import pytest
 import numpy as np
 
-from SurfaceTopography import UniformLineScan
+from SurfaceTopography import UniformLineScan, NonuniformLineScan, Topography
+
+#######################################################################
+# Fixtures
+#######################################################################
 
 
-@pytest.fixture
-def uniform_line_scan():
-    x = np.linspace(0, 4 * np.pi, 101)
-    h = np.sin(x)
-    return UniformLineScan(h, 4 * np.pi).scale(2.0)
-
-
-@pytest.mark.parametrize(['use_scale', 'use_detrend'],
-                         [(True, True), (True, False), (False, True), (False, False)])
-def test_api_uniform_line_scan(uniform_line_scan, use_scale, use_detrend):
-    """Just check whether an expected subset of pipeline functions can be executed.
-
-    Parameters
-    ----------
-    uniform_line_scan
-    use_scale: bool
-        If True, check for a scaled topography.
-    use_detrend: bool
-        If True, check for a detrended topography.
-        If `use_scale` is True, the detrending is applied afterwards.
+def id_topography_modifiers(fixture_value):
+    """Used to see whether scaled or detrended in test output.
     """
+    use_scale, use_detrend = fixture_value
+    s = ""
+    if not use_scale:
+        s += "no"
+    s += "scale-"
+    if not use_detrend:
+        s += "no"
+    s += "detrend"
+    return s
+
+
+@pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
+                ids=id_topography_modifiers)
+def uniform_line_scan(request):
+    """Returns a uniform line scan, with all combinations of scaled and detrended.
+
+    Detrended is always executed after scaling, if requested.
+
+    Returns
+    -------
+    A uniform line scan.
+    """
+    x = np.linspace(0, 4 * np.pi, 11)
+    h = np.sin(x)
+    uniform_line_scan = UniformLineScan(h, 4 * np.pi)
+    use_scale, use_detrend = request.param
     if use_scale:
         uniform_line_scan = uniform_line_scan.scale(2)
     if use_detrend:
         uniform_line_scan = uniform_line_scan.detrend('height')
+    return uniform_line_scan
 
-    expected_attributes = [
-        "rms_height_from_profile",
-        "rms_curvature_from_profile",
-        "power_spectrum_from_profile"
-    ]
 
-    for attr in expected_attributes:
-        assert hasattr(uniform_line_scan, attr)
+@pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
+                ids=id_topography_modifiers)
+def nonuniform_line_scan(request):
+    """Returns a nonuniform line scan, with all combinations of scaled and detrended.
+
+    Detrended is always executed after scaling, if requested.
+
+    Returns
+    -------
+    A nonuniform line scan.
+    """
+    x = np.array((0, 0.1, 0.2, 0.4, 0.5))
+    h = np.sin(x)
+    nonuniform_line_scan = NonuniformLineScan(x, h)
+    use_scale, use_detrend = request.param
+    if use_scale:
+        nonuniform_line_scan = nonuniform_line_scan.scale(2)
+    if use_detrend:
+        nonuniform_line_scan = nonuniform_line_scan.detrend('height')
+    return nonuniform_line_scan
+
+
+@pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
+                ids=id_topography_modifiers)
+def uniform_2d_topography(request):
+    """Returns a uniform 2D topography, with all combinations of scaled and detrended.
+
+    Detrended is always executed after scaling, if requested.
+
+    Returns
+    -------
+    A uniform 2D topography.
+    """
+    y = np.arange(10).reshape((1, -1))
+    x = np.arange(5).reshape((-1, 1))
+    arr = -2 * y + 0 * x  # only slope in y direction
+    topography = Topography(arr, (5, 10)).detrend('center')
+    use_scale, use_detrend = request.param
+    if use_scale:
+        topography = topography.scale(2)
+    if use_detrend:
+        topography = topography.detrend('height')
+    return topography
+
+#######################################################################
+# Tests
+#######################################################################
+
+
+@pytest.mark.parametrize('expected_attribute', [
+    "physical_sizes",
+    "nb_grid_pts",
+    "dim",
+    "info",
+    "is_uniform",
+    "heights",
+    "positions",
+    "mean",
+    "derivative",
+    "rms_height_from_profile",
+    "rms_slope_from_profile",
+    "rms_gradient",
+    "rms_curvature_from_profile",
+    "power_spectrum_from_profile"
+])
+def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
+    """Just check whether an expected subset of pipeline functions can be executed.
+
+    Parameters
+    ----------
+    uniform_line_scan: SurfaceTopography.UniformLineScanAndTopography.UniformLineScan
+    expected_attribute: str
+        name of the attribute which we check
+    """
+    assert hasattr(uniform_line_scan, expected_attribute)
+
+
+@pytest.mark.parametrize('expected_attribute', [
+    "physical_sizes",
+    "nb_grid_pts",
+    "dim",
+    "info",
+    "is_uniform",
+    "heights",
+    "positions",
+    "mean",
+    "derivative",
+    "rms_height_from_profile",
+    "rms_slope_from_profile",
+    "rms_gradient",
+    "rms_curvature_from_profile",
+    "power_spectrum_from_profile"
+])
+def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
+    """Just check whether an expected subset of pipeline functions can be executed.
+
+    Parameters
+    ----------
+    nonuniform_line_scan: SurfaceTopography.UniformLineScanAndTopography.NonuniformLineScan
+    expected_attribute: str
+        name of the attribute which we check
+    """
+    assert hasattr(nonuniform_line_scan, expected_attribute)
+
+
+@pytest.mark.parametrize('expected_attribute', [
+    "physical_sizes",
+    "nb_grid_pts",
+    "dim",
+    "info",
+    "is_uniform",
+    "heights",
+    "positions",
+    "mean",
+    "derivative",
+    "rms_height_from_area",
+    "rms_height_from_profile",
+    "rms_slope_from_profile",
+    "rms_gradient",
+    "rms_curvature_from_area",
+    "rms_curvature_from_profile",
+    "power_spectrum_from_area",
+    "power_spectrum_from_profile"
+])
+def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
+    """Just check whether an expected subset of pipeline functions can be executed.
+
+    Parameters
+    ----------
+    uniform_2d_topography: SurfaceTopography.UniformLineScanAndTopography.NonuniformLineScan
+    expected_attribute: str
+        name of the attribute which we check
+    """
+    assert hasattr(uniform_2d_topography, expected_attribute)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,6 +28,7 @@ uniform_attributes = [
 ]
 
 nonuniform_attributes = [
+    "x_range",
 ]
 
 profile_functions = [

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -75,6 +75,7 @@ def apply_param(topography, param):
         assert hasattr(topography, 'scale_factor')
     if use_detrend:
         topography = topography.detrend('height')
+        assert hasattr(topography, 'detrend_mode')
     return topography
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -3,6 +3,22 @@ import numpy as np
 
 from SurfaceTopography import UniformLineScan, NonuniformLineScan, Topography
 
+
+common_attributes = [
+    "physical_sizes",
+    "nb_grid_pts",
+    "dim",
+    "info",
+    "is_uniform",
+    "is_periodic",
+    "heights",
+    "positions",
+    "positions_and_heights",
+    "mean",
+    "derivative",
+    "squeeze",
+]
+
 #######################################################################
 # Fixtures
 #######################################################################
@@ -93,21 +109,13 @@ def uniform_2d_topography(request):
 #######################################################################
 
 
-@pytest.mark.parametrize('expected_attribute', [
-    "physical_sizes",
-    "nb_grid_pts",
-    "dim",
-    "info",
-    "is_uniform",
-    "heights",
-    "positions",
-    "mean",
-    "derivative",
+@pytest.mark.parametrize('expected_attribute', common_attributes + [
     "rms_height_from_profile",
     "rms_slope_from_profile",
     "rms_gradient",
     "rms_curvature_from_profile",
-    "power_spectrum_from_profile"
+    "power_spectrum_from_profile",
+    "variable_bandwidth",
 ])
 def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
@@ -121,21 +129,13 @@ def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     assert hasattr(uniform_line_scan, expected_attribute)
 
 
-@pytest.mark.parametrize('expected_attribute', [
-    "physical_sizes",
-    "nb_grid_pts",
-    "dim",
-    "info",
-    "is_uniform",
-    "heights",
-    "positions",
-    "mean",
-    "derivative",
+@pytest.mark.parametrize('expected_attribute', common_attributes + [
     "rms_height_from_profile",
     "rms_slope_from_profile",
     "rms_gradient",
     "rms_curvature_from_profile",
-    "power_spectrum_from_profile"
+    "power_spectrum_from_profile",
+    "variable_bandwidth",
 ])
 def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
@@ -149,16 +149,8 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     assert hasattr(nonuniform_line_scan, expected_attribute)
 
 
-@pytest.mark.parametrize('expected_attribute', [
-    "physical_sizes",
-    "nb_grid_pts",
-    "dim",
-    "info",
-    "is_uniform",
-    "heights",
-    "positions",
-    "mean",
-    "derivative",
+@pytest.mark.parametrize('expected_attribute', common_attributes + [
+    "area_per_pt",
     "rms_height_from_area",
     "rms_height_from_profile",
     "rms_slope_from_profile",
@@ -166,7 +158,8 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     "rms_curvature_from_area",
     "rms_curvature_from_profile",
     "power_spectrum_from_area",
-    "power_spectrum_from_profile"
+    "power_spectrum_from_profile",
+    "variable_bandwidth",
 ])
 def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+
+from SurfaceTopography import UniformLineScan
+
+
+@pytest.fixture
+def uniform_line_scan():
+    x = np.linspace(0, 4 * np.pi, 101)
+    h = np.sin(x)
+    return UniformLineScan(h, 4 * np.pi).scale(2.0)
+
+
+@pytest.mark.parametrize(['use_scale', 'use_detrend'],
+                         [(True, True), (True, False), (False, True), (False, False)])
+def test_api_uniform_line_scan(uniform_line_scan, use_scale, use_detrend):
+    """Just check whether an expected subset of pipeline functions can be executed.
+
+    Parameters
+    ----------
+    uniform_line_scan
+    use_scale: bool
+        If True, check for a scaled topography.
+    use_detrend: bool
+        If True, check for a detrended topography.
+        If `use_scale` is True, the detrending is applied afterwards.
+    """
+    if use_scale:
+        uniform_line_scan = uniform_line_scan.scale(2)
+    if use_detrend:
+        uniform_line_scan = uniform_line_scan.detrend('height')
+
+    expected_attributes = [
+        "rms_height_from_profile",
+        "rms_curvature_from_profile",
+        "power_spectrum_from_profile"
+    ]
+
+    for attr in expected_attributes:
+        assert hasattr(uniform_line_scan, attr)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -22,6 +22,7 @@ common_attributes = [
 ]
 
 uniform_attributes = [
+    "area_per_pt",
     "has_undefined_data",
     "is_domain_decomposed",
     "pixel_size",
@@ -31,16 +32,34 @@ nonuniform_attributes = [
     "x_range",
 ]
 
+common_functions = [
+    "detrend",
+]
+
+uniform_functions = [
+    "filter",
+    "interpolate_bicubic",
+    "interpolate_fourier",
+    "longcut",
+    "mirror_stitch",
+    "shortcut",
+    "window",
+]
+
+nonuniform_functions = [
+
+]
+
 profile_functions = [
     "rms_height_from_profile",
     "rms_slope_from_profile",
     "rms_curvature_from_profile",
+    "autocorrelation_from_profile",
     "power_spectrum_from_profile",
     "variable_bandwidth",
 ]
 
 area_functions = [
-    "area_per_pt",
     "rms_height_from_area",
     "rms_gradient",
     "rms_curvature_from_area",
@@ -131,13 +150,14 @@ def uniform_2d_topography(request):
     return apply_param(topography, request.param)
 
 
-
 #######################################################################
 # Tests
 #######################################################################
 
 
-@pytest.mark.parametrize('expected_attribute', common_attributes + uniform_attributes + profile_functions)
+@pytest.mark.parametrize('expected_attribute',
+                         common_attributes + common_functions + uniform_attributes + uniform_functions +
+                         profile_functions)
 def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 
@@ -150,7 +170,9 @@ def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     assert hasattr(uniform_line_scan, expected_attribute)
 
 
-@pytest.mark.parametrize('expected_attribute', common_attributes + nonuniform_attributes + profile_functions)
+@pytest.mark.parametrize('expected_attribute',
+                         common_attributes + common_functions + nonuniform_attributes + nonuniform_functions +
+                         profile_functions)
 def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 
@@ -164,7 +186,8 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
 
 
 @pytest.mark.parametrize('expected_attribute',
-                         common_attributes + uniform_attributes + profile_functions + area_functions)
+                         common_attributes + common_functions + uniform_attributes + uniform_functions +
+                         profile_functions + area_functions)
 def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -11,7 +11,6 @@ common_properties = [
     "is_periodic",
     "nb_grid_pts",
     "physical_sizes",
-    "squeeze",
 ]
 
 uniform_properties = [
@@ -25,6 +24,8 @@ nonuniform_properties = [
     "x_range",
 ]
 
+properties = common_properties + uniform_properties + nonuniform_properties
+
 common_functions = [
     "bandwidth",
     "detrend",
@@ -35,6 +36,7 @@ common_functions = [
     "min",
     "positions",
     "positions_and_heights",
+    "squeeze",
 ]
 
 uniform_functions = [
@@ -68,6 +70,8 @@ area_functions = [
     "power_spectrum_from_area",
     "power_spectrum_from_profile",
 ]
+
+functions = common_functions + uniform_functions + nonuniform_functions + profile_functions + area_functions
 
 
 #######################################################################
@@ -156,6 +160,13 @@ def uniform_2d_topography(request):
 # Tests
 #######################################################################
 
+def checkattr(obj, attr):
+    assert hasattr(obj, attr)
+    if attr in properties:
+        assert isinstance(getattr(type(obj), attr), property)
+    if attr in functions:
+        assert callable(getattr(obj, attr))
+
 
 @pytest.mark.parametrize('expected_attribute',
                          common_properties + common_functions + uniform_properties + uniform_functions +
@@ -169,7 +180,7 @@ def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     expected_attribute: str
         name of the attribute which we check
     """
-    assert hasattr(uniform_line_scan, expected_attribute)
+    checkattr(uniform_line_scan, expected_attribute)
 
 
 @pytest.mark.parametrize('expected_attribute',
@@ -184,7 +195,7 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     expected_attribute: str
         name of the attribute which we check
     """
-    assert hasattr(nonuniform_line_scan, expected_attribute)
+    checkattr(nonuniform_line_scan, expected_attribute)
 
 
 @pytest.mark.parametrize('expected_attribute',
@@ -199,4 +210,4 @@ def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
     expected_attribute: str
         name of the attribute which we check
     """
-    assert hasattr(uniform_2d_topography, expected_attribute)
+    checkattr(uniform_2d_topography, expected_attribute)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -3,37 +3,38 @@ import numpy as np
 
 from SurfaceTopography import UniformLineScan, NonuniformLineScan, Topography
 
-common_attributes = [
+common_properties = [
     "communicator",
-    "derivative",
     "dim",
     "info",
     "is_uniform",
     "is_periodic",
-    "heights",
-    "positions",
-    "positions_and_heights",
-    "mean",
-    "min",
-    "max",
     "nb_grid_pts",
     "physical_sizes",
     "squeeze",
 ]
 
-uniform_attributes = [
+uniform_properties = [
     "area_per_pt",
     "has_undefined_data",
     "is_domain_decomposed",
     "pixel_size",
 ]
 
-nonuniform_attributes = [
+nonuniform_properties = [
     "x_range",
 ]
 
 common_functions = [
+    "bandwidth",
     "detrend",
+    "derivative",
+    "heights",
+    "max",
+    "mean",
+    "min",
+    "positions",
+    "positions_and_heights",
 ]
 
 uniform_functions = [
@@ -47,7 +48,8 @@ uniform_functions = [
 ]
 
 nonuniform_functions = [
-
+    "checkerboard_detrend",
+    "variable_bandwidth",
 ]
 
 profile_functions = [
@@ -56,12 +58,12 @@ profile_functions = [
     "rms_curvature_from_profile",
     "autocorrelation_from_profile",
     "power_spectrum_from_profile",
-    "variable_bandwidth",
 ]
 
 area_functions = [
     "rms_height_from_area",
     "rms_gradient",
+    "rms_laplacian",
     "rms_curvature_from_area",
     "power_spectrum_from_area",
     "power_spectrum_from_profile",
@@ -156,7 +158,7 @@ def uniform_2d_topography(request):
 
 
 @pytest.mark.parametrize('expected_attribute',
-                         common_attributes + common_functions + uniform_attributes + uniform_functions +
+                         common_properties + common_functions + uniform_properties + uniform_functions +
                          profile_functions)
 def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
@@ -171,7 +173,7 @@ def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
 
 
 @pytest.mark.parametrize('expected_attribute',
-                         common_attributes + common_functions + nonuniform_attributes + nonuniform_functions +
+                         common_properties + common_functions + nonuniform_properties + nonuniform_functions +
                          profile_functions)
 def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
@@ -186,7 +188,7 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
 
 
 @pytest.mark.parametrize('expected_attribute',
-                         common_attributes + common_functions + uniform_attributes + uniform_functions +
+                         common_properties + common_functions + uniform_properties + uniform_functions +
                          profile_functions + area_functions)
 def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -38,6 +38,16 @@ def id_topography_modifiers(fixture_value):
     return s
 
 
+def apply_param(topography, param):
+    use_scale, use_detrend = param
+    if use_scale:
+        topography = topography.scale(2)
+        assert hasattr(topography, 'scale_factor')
+    if use_detrend:
+        topography = topography.detrend('height')
+    return topography
+
+
 @pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
                 ids=id_topography_modifiers)
 def uniform_line_scan(request):
@@ -52,12 +62,7 @@ def uniform_line_scan(request):
     x = np.linspace(0, 4 * np.pi, 11)
     h = np.sin(x)
     uniform_line_scan = UniformLineScan(h, 4 * np.pi)
-    use_scale, use_detrend = request.param
-    if use_scale:
-        uniform_line_scan = uniform_line_scan.scale(2)
-    if use_detrend:
-        uniform_line_scan = uniform_line_scan.detrend('height')
-    return uniform_line_scan
+    return apply_param(uniform_line_scan, request.param)
 
 
 @pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
@@ -74,12 +79,7 @@ def nonuniform_line_scan(request):
     x = np.array((0, 0.1, 0.2, 0.4, 0.5))
     h = np.sin(x)
     nonuniform_line_scan = NonuniformLineScan(x, h)
-    use_scale, use_detrend = request.param
-    if use_scale:
-        nonuniform_line_scan = nonuniform_line_scan.scale(2)
-    if use_detrend:
-        nonuniform_line_scan = nonuniform_line_scan.detrend('height')
-    return nonuniform_line_scan
+    return apply_param(nonuniform_line_scan, request.param)
 
 
 @pytest.fixture(params=[(True, True), (True, False), (False, True), (False, False)],
@@ -97,12 +97,8 @@ def uniform_2d_topography(request):
     x = np.arange(5).reshape((-1, 1))
     arr = -2 * y + 0 * x  # only slope in y direction
     topography = Topography(arr, (5, 10)).detrend('center')
-    use_scale, use_detrend = request.param
-    if use_scale:
-        topography = topography.scale(2)
-    if use_detrend:
-        topography = topography.detrend('height')
-    return topography
+    return apply_param(topography, request.param)
+
 
 #######################################################################
 # Tests

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -3,10 +3,9 @@ import numpy as np
 
 from SurfaceTopography import UniformLineScan, NonuniformLineScan, Topography
 
-
 common_attributes = [
-    "physical_sizes",
-    "nb_grid_pts",
+    "communicator",
+    "derivative",
     "dim",
     "info",
     "is_uniform",
@@ -15,9 +14,39 @@ common_attributes = [
     "positions",
     "positions_and_heights",
     "mean",
-    "derivative",
+    "min",
+    "max",
+    "nb_grid_pts",
+    "physical_sizes",
     "squeeze",
 ]
+
+uniform_attributes = [
+    "has_undefined_data",
+    "is_domain_decomposed",
+    "pixel_size",
+]
+
+nonuniform_attributes = [
+]
+
+profile_functions = [
+    "rms_height_from_profile",
+    "rms_slope_from_profile",
+    "rms_curvature_from_profile",
+    "power_spectrum_from_profile",
+    "variable_bandwidth",
+]
+
+area_functions = [
+    "area_per_pt",
+    "rms_height_from_area",
+    "rms_gradient",
+    "rms_curvature_from_area",
+    "power_spectrum_from_area",
+    "power_spectrum_from_profile",
+]
+
 
 #######################################################################
 # Fixtures
@@ -100,19 +129,13 @@ def uniform_2d_topography(request):
     return apply_param(topography, request.param)
 
 
+
 #######################################################################
 # Tests
 #######################################################################
 
 
-@pytest.mark.parametrize('expected_attribute', common_attributes + [
-    "rms_height_from_profile",
-    "rms_slope_from_profile",
-    "rms_gradient",
-    "rms_curvature_from_profile",
-    "power_spectrum_from_profile",
-    "variable_bandwidth",
-])
+@pytest.mark.parametrize('expected_attribute', common_attributes + uniform_attributes + profile_functions)
 def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 
@@ -125,14 +148,7 @@ def test_api_uniform_line_scan(uniform_line_scan, expected_attribute):
     assert hasattr(uniform_line_scan, expected_attribute)
 
 
-@pytest.mark.parametrize('expected_attribute', common_attributes + [
-    "rms_height_from_profile",
-    "rms_slope_from_profile",
-    "rms_gradient",
-    "rms_curvature_from_profile",
-    "power_spectrum_from_profile",
-    "variable_bandwidth",
-])
+@pytest.mark.parametrize('expected_attribute', common_attributes + nonuniform_attributes + profile_functions)
 def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 
@@ -145,18 +161,8 @@ def test_api_nonuniform_line_scan(nonuniform_line_scan, expected_attribute):
     assert hasattr(nonuniform_line_scan, expected_attribute)
 
 
-@pytest.mark.parametrize('expected_attribute', common_attributes + [
-    "area_per_pt",
-    "rms_height_from_area",
-    "rms_height_from_profile",
-    "rms_slope_from_profile",
-    "rms_gradient",
-    "rms_curvature_from_area",
-    "rms_curvature_from_profile",
-    "power_spectrum_from_area",
-    "power_spectrum_from_profile",
-    "variable_bandwidth",
-])
+@pytest.mark.parametrize('expected_attribute',
+                         common_attributes + uniform_attributes + profile_functions + area_functions)
 def test_api_uniform_2d_topography(uniform_2d_topography, expected_attribute):
     """Just check whether an expected subset of pipeline functions can be executed.
 

--- a/test/test_scalar_parameters.py
+++ b/test/test_scalar_parameters.py
@@ -122,7 +122,7 @@ def test_rms_curvature_paraboloid_uniform_1D():
     surf = UniformLineScan(heights, physical_sizes=(n,),
                            periodic=False)
     # central finite differences are second order and so exact for the parabola
-    assert abs((surf.rms_curvature_from_area() - curvature) / curvature) < 1e-14
+    assert abs((surf.rms_curvature_from_profile() - curvature) / curvature) < 1e-14
 
 
 @pytest.mark.skipif(

--- a/test/test_topography.py
+++ b/test/test_topography.py
@@ -474,16 +474,16 @@ class DetrendedSurfaceTest(unittest.TestCase):
         self.assertAlmostEqual(surf.mean(), 0)
         self.assertAlmostEqual(surf.rms_slope_from_profile(), 0)
         self.assertTrue(
-            surf.rms_height_from_area() < UniformLineScan(arr, arr.shape).rms_height_from_area())
+            surf.rms_height_from_profile() < UniformLineScan(arr, arr.shape).rms_height_from_profile())
 
         surf2 = UniformLineScan(arr, (1,)).detrend(detrend_mode='height')
         self.assertEqual(surf.dim, 1)
         self.assertTrue(surf2.is_uniform)
         self.assertAlmostEqual(surf2.rms_slope_from_profile(), 0)
         self.assertTrue(
-            surf2.rms_height_from_area() < UniformLineScan(arr, arr.shape).rms_height_from_area())
+            surf2.rms_height_from_profile() < UniformLineScan(arr, arr.shape).rms_height_from_profile())
 
-        self.assertAlmostEqual(surf.rms_height_from_area(), surf2.rms_height_from_area())
+        self.assertAlmostEqual(surf.rms_height_from_profile(), surf2.rms_height_from_profile())
 
         x, z = surf2.positions_and_heights()
         self.assertAlmostEqual(np.mean(np.diff(x)),
@@ -548,8 +548,8 @@ class DetrendedSurfaceTest(unittest.TestCase):
                                    detrended.rms_slope_from_profile(),
                                    msg=mode)
             else:
-                self.assertGreater(t.rms_height_from_area(),
-                                   detrended.rms_height_from_area(),
+                self.assertGreater(t.rms_height_from_profile(),
+                                   detrended.rms_height_from_profile(),
                                    msg=mode)
 
     def test_smooth_without_size(self):


### PR DESCRIPTION
Because of #92 and #95 I propose to create parametrized tests which check the existence of attributes for
uniform and non-uniform line scans and for 2d topographies at different stages of the pipeline. 

The tests in this PR check a list of attributes for a combination of (un-)scaled, (not) detrended topographies.
Currently 200+ tests altogether, which fail in some cases:

- "rms_curvature_from_profile" is missing for uniform line scan
- "rms_gradient" for nonuniform line scans (expected?)
- "rms_curvature_from_profile" for uniform 2d topographies (expected?)
- "squeeze" for line scans if not scaled or detrended

Could you help me fixing those in this PR or changing the list of desired attributes (methods/properties) in the test?

Feel free to add/remove attributes names for the individual topography classes.