### PR TITLE
21 fix missing matplotlib dep issue 120

### DIFF
--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -7,6 +7,12 @@ Deprecations in version 1.0
 - `unit` entry for the `info` dictionary will disappear
 - `scale_factor` property for scaled topographies  will disappear
 
+v0.95.1 (12Jul21)
+-----------------
+
+- Fixed missing dependency for matplotlib in setup.py (#120)
+- Fixed building wheel when numpy is not installed yet (#119)
+
 v0.95.0 (07Jul21)
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -146,5 +146,6 @@ setup(
         'pyyaml',
         'Pillow',
         'requests',
+        'matplotlib>=1.0.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
         'pytest',
     ],
     install_requires=[
-        'numpy>=1.11.0',
+        'numpy>=1.16.3',
         'NuMPI>=0.1.4',
         'muFFT>=0.12.0',
         'igor',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ extensions = [
 
 setup(
     name="SurfaceTopography",
-    cmdclass={'build_ext': CustomBuildExtCommand},
+    cmdclass={'build_ext': CustomBuildExtCommand} if np else {},
     scripts=scripts,
     packages=find_packages(),
     package_data={'': ['ChangeLog.md']},


### PR DESCRIPTION
I have some issues with the current version 0.95.0, especially it cannot be used if matplotlib
and numpy are not already installed on the system. This happens for me when building docker containers.

This PR should close #119 and #120.