### PR TITLE
API: ChannelInfo now has `is_uniform` and `has_undefined_data` proper…

### DIFF
--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -7,6 +7,13 @@ Deprecations in version 1.0
 - `unit` entry for the `info` dictionary will disappear
 - `scale_factor` property for scaled topographies will disappear
 
+v0.101.0 (25Nov21)
+------------------
+
+- API: ChannelInfo now has `is_uniform` and `has_undefined_data` properties
+  that indicate the structure of the underlying data (if known after reading
+  file headers)
+
 v0.100.3 (24Nov21)
 ------------------
 

--- a/SurfaceTopography/IO/DI.py
+++ b/SurfaceTopography/IO/DI.py
@@ -198,6 +198,7 @@ The reader supports V4.3 and later version of the format.
                                           physical_sizes=(sx, sy),
                                           height_scale_factor=height_scale_factor,
                                           periodic=False,
+                                          uniform=True,
                                           unit=unit,
                                           info=info)
                     self._channels.append(channel)

--- a/SurfaceTopography/IO/FromFile.py
+++ b/SurfaceTopography/IO/FromFile.py
@@ -58,7 +58,7 @@ def binary(func):
 
 
 def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
-                        name=None, description=None, uniform=None):
+                        name=None, description=None):
     class WrappedReader(ReaderBase):
         """
         emulates the new implementation of the readers

--- a/SurfaceTopography/IO/FromFile.py
+++ b/SurfaceTopography/IO/FromFile.py
@@ -58,7 +58,7 @@ def binary(func):
 
 
 def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
-                        name=None, description=None):
+                        name=None, description=None, uniform=None):
     class WrappedReader(ReaderBase):
         """
         emulates the new implementation of the readers
@@ -93,6 +93,8 @@ def make_wrapped_reader(reader_func, class_name='WrappedReader', format=None,
                 name=self._channel_name,
                 dim=self._topography.dim,
                 unit=self._topography.unit,
+                uniform=self._topography.is_uniform,
+                undefined_data=self._topography.has_undefined_data,
                 info=self._topography.info,
                 nb_grid_pts=self._topography.nb_grid_pts,
                 physical_sizes=self._topography.physical_sizes,

--- a/SurfaceTopography/IO/H5.py
+++ b/SurfaceTopography/IO/H5.py
@@ -55,6 +55,7 @@ The original contact mechanics challenge data can be downloaded
                             0,  # channel index
                             name='Default',
                             dim=len(self._h5['surface'].shape),
+                            uniform=True,
                             nb_grid_pts=self._h5['surface'].shape)]
 
     def topography(self, channel_index=None, physical_sizes=None, height_scale_factor=None, unit=None, info={},

--- a/SurfaceTopography/IO/IBW.py
+++ b/SurfaceTopography/IO/IBW.py
@@ -122,7 +122,7 @@ on the physical size of the topography map as well as its units.
         #
         self._channels = [
             ChannelInfo(self, i, name=cn, dim=2, nb_grid_pts=(nx, ny), physical_sizes=self._physical_sizes,
-                        unit=self._data_unit, height_scale_factor=1)
+                        unit=self._data_unit, height_scale_factor=1, uniform=True)
             for i, cn in enumerate(self._channel_names)]
 
         # Shall we use the channel names in order to assign a unit as Gwyddion

--- a/SurfaceTopography/IO/MI.py
+++ b/SurfaceTopography/IO/MI.py
@@ -190,6 +190,7 @@ well as its units.
                             dim=len(self._nb_grid_pts),
                             nb_grid_pts=self._nb_grid_pts,
                             physical_sizes=self._physical_sizes,
+                            uniform=True,
                             unit=channel.unit,
                             info=channel.meta)
                 for i, channel in enumerate(self.mifile.channels)]

--- a/SurfaceTopography/IO/Matlab.py
+++ b/SurfaceTopography/IO/Matlab.py
@@ -70,6 +70,7 @@ These need to be manually provided by the user.
                                                len(self._channels),
                                                name=name,
                                                dim=len(shape),
+                                               uniform=True,
                                                nb_grid_pts=shape)
                     # no height scale factor given in mat file
 

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -232,6 +232,7 @@ plt.show()
     def channels(self):
         if self._x_dim is not None:
             # This is a uniform topography
+            uniform = True
             try:
                 # netCDF4
                 nx = self._x_dim.size
@@ -250,6 +251,7 @@ plt.show()
                 nb_grid_pts = (nx, ny)
         else:
             # This is a nonuniform line scan
+            uniform = False
             try:
                 # netCDF4
                 nx = self._x_dim.size
@@ -263,6 +265,8 @@ plt.show()
                             nb_grid_pts=nb_grid_pts,
                             physical_sizes=self._physical_sizes,
                             periodic=self._periodic,
+                            uniform=uniform,
+                            undefined_data=self._mask_var is not None,
                             unit=self._unit,
                             info=self._info)]
 

--- a/SurfaceTopography/IO/NPY.py
+++ b/SurfaceTopography/IO/NPY.py
@@ -93,6 +93,7 @@ manually provided by the user.
         return [ChannelInfo(self, 0,
                             name='Default',
                             dim=len(self._nb_grid_pts),
+                            uniform=True,
                             nb_grid_pts=self._nb_grid_pts)]
 
     def topography(self, channel_index=None, physical_sizes=None, height_scale_factor=None, unit=None, info={},

--- a/SurfaceTopography/IO/OPD.py
+++ b/SurfaceTopography/IO/OPD.py
@@ -111,6 +111,7 @@ interferometer.
                                                    name=n,
                                                    dim=2,
                                                    nb_grid_pts=(nx, ny),
+                                                   uniform=True,
                                                    unit='mm',
                                                    info=dict(file_offset=f.tell(), dtype=dtype))]
                     channel_index += 1

--- a/SurfaceTopography/IO/OPDx.py
+++ b/SurfaceTopography/IO/OPDx.py
@@ -193,6 +193,7 @@ File format of the Bruker Dektak XT* series stylus profilometer.
                                            dim=1,
                                            nb_grid_pts=nb_grid_pts,
                                            physical_sizes=physical_size,
+                                           uniform=True,
                                            unit=unit,
                                            height_scale_factor=height_scale_factor,
                                            info=self.info_from_manifest(prefix))]
@@ -227,6 +228,7 @@ File format of the Bruker Dektak XT* series stylus profilometer.
                                        dim=2,
                                        nb_grid_pts=(nb_grid_pts_x, nb_grid_pts_y),
                                        physical_sizes=(physical_size_x, physical_size_y),
+                                       uniform=True,
                                        unit=unit_x,
                                        height_scale_factor=height_scale_factor,
                                        info=self.info_from_manifest(prefix))]

--- a/SurfaceTopography/IO/Reader.py
+++ b/SurfaceTopography/IO/Reader.py
@@ -66,10 +66,12 @@ class ChannelInfo:
             Whether the SurfaceTopography should be interpreted as one period of
             a periodic surface. This will affect the PSD and autocorrelation
             calculations (windowing).
-        unit : str, optional
-            Length unit of measurement.
         uniform : bool, optional
             Data is uniform.
+        has_undefined_data : bool, optional
+            Underlying data has missing/undefined points.
+        unit : str, optional
+            Length unit of measurement.
         info : dict, optional
             Meta data found in the file. (Default: {})
         """

--- a/SurfaceTopography/IO/Reader.py
+++ b/SurfaceTopography/IO/Reader.py
@@ -37,37 +37,41 @@ class ChannelInfo:
     Information on topography channels contained within a file.
     """
 
-    def __init__(self, reader, index, name=None, dim=None, nb_grid_pts=None,
-                 physical_sizes=None, height_scale_factor=None, periodic=None, unit=None, info={}):
+    def __init__(self, reader, index, name=None, dim=None, nb_grid_pts=None, physical_sizes=None,
+                 height_scale_factor=None, periodic=None, uniform=None, undefined_data=None, unit=None, info={}):
         """
         Initialize the channel. Use as many information from the file as
-        possible by passing it in the keyword arguments.
+        possible by passing it in the keyword arguments. Keyword arguments
+        can be None if the information cannot be determined. (This is the
+        default for all keyword arguments.)
 
         Arguments
         ---------
-        reader : ReaderBase
+        reader : :obj:`ReaderBase`
             Reader instance this channel is coming from.
         index : int
             Index of channel in the file, where zero is the first channel.
-        name : str
+        name : str, optional
             Name of the channel. If no name is given, "channel <index>" will
             be used, where "<index>" is replaced with the index.
-        dim : int
+        dim : int, optional
             Number of dimensions.
-        nb_grid_pts : tuple of ints
+        nb_grid_pts : tuple of ints, optional
             Number grid points in each dimension.
-        physical_sizes : tuple of floats
+        physical_sizes : tuple of floats, optional
             Physical dimensions.
-        height_scale_factor: float
+        height_scale_factor: float, optional
             Number by which all heights have been multiplied.
-        periodic : bool
+        periodic : bool, optional
             Whether the SurfaceTopography should be interpreted as one period of
             a periodic surface. This will affect the PSD and autocorrelation
             calculations (windowing).
-        unit : str
+        unit : str, optional
             Length unit of measurement.
-        info : dict
-            Meta data found in the file.
+        uniform : bool, optional
+            Data is uniform.
+        info : dict, optional
+            Meta data found in the file. (Default: {})
         """
         self._reader = reader
         self._index = int(index)
@@ -80,6 +84,8 @@ class ChannelInfo:
             if physical_sizes is None else tuple(np.ravel(physical_sizes))
         self._height_scale_factor = height_scale_factor
         self._periodic = periodic
+        self._uniform = uniform
+        self._undefined_data = undefined_data
         self._unit = unit
         if info is None:
             self._info = None
@@ -95,28 +101,28 @@ class ChannelInfo:
 
         Arguments
         ---------
-        physical_sizes : tuple of floats
+        physical_sizes : tuple of floats, optional
             Physical size of the topography. It is necessary to specify this
             if no physical size is found in the data file. If there is a
             physical size, then this parameter will override the physical
             size found in the data file.
-        height_scale_factor : float
+        height_scale_factor : float, optional
             Factor by which the heights should be multiplied.
             This parameter is only available for file formats that do not provide
             metadata information about units and associated length scales.
-        unit : str
+        unit : str, optional
             Length unit of measurement.
-        info : dict
+        info : dict, optional
             This dictionary will be appended to the info dictionary returned
             by the reader.
-        periodic : bool
+        periodic : bool, optional
             Whether the SurfaceTopography should be interpreted as one period of
             a periodic surface. This will affect the PSD and autocorrelation
             calculations (windowing)
-        subdomain_locations : tuple of ints
+        subdomain_locations : tuple of ints, optional
             Origin (location) of the subdomain handled by the present MPI
             process.
-        nb_subdomain_grid_pts : tuple of ints
+        nb_subdomain_grid_pts : tuple of ints, optional
             Number of grid points within the subdomain handled by the present
             MPI process.
 
@@ -209,6 +215,20 @@ class ChannelInfo:
         boundaries.
         """
         return self._periodic
+
+    @property
+    def is_uniform(self):
+        """
+        Return whether the topography is uniform.
+        """
+        return self._uniform
+
+    @property
+    def has_undefined_data(self):
+        """
+        Return whether the topography has undefined data.
+        """
+        return self._undefined_data
 
     @property
     def pixel_size(self):

--- a/SurfaceTopography/IO/ZON.py
+++ b/SurfaceTopography/IO/ZON.py
@@ -119,6 +119,7 @@ This reader open ZON files that are written by some Keyence instruments.
                     ChannelInfo(self, 0, name='default', dim=2, nb_grid_pts=(width, height),
                                 physical_sizes=(width * meter_per_pixel, height * meter_per_pixel),
                                 height_scale_factor=self._orig_height_scale_factor, unit='m',
+                                uniform=True,
                                 info={'data_uuid': HEIGHT_DATA_UUID,
                                       'meter_per_pixel': meter_per_pixel,
                                       'meter_per_unit': meter_per_unit})]

--- a/SurfaceTopography/UniformLineScanAndTopography.py
+++ b/SurfaceTopography/UniformLineScanAndTopography.py
@@ -127,7 +127,7 @@ class UniformLineScan(AbstractTopography, UniformTopographyInterface):
 
     @property
     def has_undefined_data(self):
-        return np.ma.getmask(self._heights) is not np.ma.nomask
+        return np.ma.getmaskarray(self._heights).sum() > 0
 
     def positions(self, meshgrid=True):
         """
@@ -361,8 +361,7 @@ class Topography(AbstractTopography, UniformTopographyInterface):
 
     @property
     def has_undefined_data(self):
-        return Reduction(self._communicator).sum(
-            np.ma.getmask(self._heights) is not np.ma.nomask and np.ma.getmask(self._heights).sum() > 0)
+        return Reduction(self._communicator).sum(np.ma.getmaskarray(self._heights).sum()) > 0
 
     def positions(self, meshgrid=True):
         """

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -305,7 +305,8 @@ def test_nb_grid_pts_and_physical_sizes_are_tuples_or_none(fn):
             f'{fn} - {r.__class__}: {r.default_channel.physical_sizes}'
 
 
-@pytest.mark.parametrize('fn', text_example_file_list + text_example_without_size_file_list + binary_example_file_list)
+@pytest.mark.parametrize('fn', text_example_file_list + text_example_without_size_file_list + binary_example_file_list +
+                         binary_without_stream_support_example_file_list)
 def test_reader_topography_same(fn):
     """
     Tests that properties like physical sizes, units and nb_grid_pts are

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -336,9 +336,15 @@ def test_reader_topography_same(fn):
         if channel.height_scale_factor is not None and hasattr(topography, 'scale_factor'):
             assert channel.height_scale_factor == topography.scale_factor
 
+        if channel.is_periodic is not None:
+            assert isinstance(channel.is_periodic, (bool, np.bool_))
+            assert channel.is_periodic == topography.is_periodic
+
+        assert isinstance(channel.is_uniform, (bool, np.bool_))
         assert channel.is_uniform == topography.is_uniform
 
         if channel.has_undefined_data is not None:
+            assert isinstance(channel.has_undefined_data, (bool, np.bool_))
             assert channel.has_undefined_data == topography.has_undefined_data
 
 

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -335,6 +335,11 @@ def test_reader_topography_same(fn):
         if channel.height_scale_factor is not None and hasattr(topography, 'scale_factor'):
             assert channel.height_scale_factor == topography.scale_factor
 
+        assert channel.is_uniform == topography.is_uniform
+
+        if channel.has_undefined_data is not None:
+            assert channel.has_undefined_data == topography.has_undefined_data
+
 
 @pytest.mark.parametrize('fn', text_example_file_list + text_example_without_size_file_list + binary_example_file_list)
 def test_reader_args_doesnt_overwrite_data_from_file(fn):


### PR DESCRIPTION
…ties that indicate the structure of the underlying data (if known after reading file headers)