### PR TITLE
Fix mitutoyo reader

### DIFF
--- a/SurfaceTopography/IO/Mitutoyo.py
+++ b/SurfaceTopography/IO/Mitutoyo.py
@@ -56,8 +56,8 @@ surface roughness testers.
 
         The reader expects a line scan by positions and heights in columns
         5 and 6 (E, F) and tries to extract standard roughness metrics from
-        column 1 (A) on the sheet 'DATA'. The reader extracts expects the
-        acquisition date on sheet in column 5 (E) row 2 on sheet 'Certificate'.
+        column 1 (A) on the sheet 'DATA'. The reader expects the
+        acquisition date in column 5 (E) row 2 on sheet 'Certificate'.
 
         Parameters
         ----------
@@ -126,8 +126,11 @@ surface roughness testers.
 
             self._unit = _h_unit
 
-            # we assume the data series to start at zero x
-            self._physical_sizes = np.max(self._x) - np.min(self._x)
+            # with n data points spaced by distance dx,
+            #   internal format of positions in uniform line scan is [0, dx, 2*dx, ... (n-1)*dx]
+            #   Mitutoyo format of positions is [dx, 2*dx, ..., n*dx]
+            # _physical_sizes must capture n*dx to result in valid zero-initiated uniform distribution
+            self._physical_sizes = np.max(self._x)
 
             self._info = {
                 'roughness_metrics': _roughness_metrics_list,
@@ -185,7 +188,7 @@ surface roughness testers.
         channel = self._channels[channel_index]
 
         # Make sure `physical_sizes` is present, either fixed by the file
-        # or given by the user. Also make sure that if the user specifies it
+        # or given by the user. Also make sure that if the user specifies it,
         # it cannot be set in the file. (We cannot override metadata from
         # files.)
         physical_sizes = self._check_physical_sizes(physical_sizes,

--- a/SurfaceTopography/IO/Mitutoyo.py
+++ b/SurfaceTopography/IO/Mitutoyo.py
@@ -88,9 +88,14 @@ surface roughness testers.
             else:
                 self._uniform = False
                 # height values are assigned to the "end" of each "pixel" in the
-                # xlsx format, starting at non-zero x. Here we shift positions
-                # by half a distance each to have non-uniform profiles centered
-                _x = _x - np.insert(_diff, 0, _x[0]) * 0.5
+                # xlsx format, starting at non-zero x. Here we used to shift
+                # positions by half a distance each to have non-uniform profiles
+                # element-centered positions:
+                # _x = _x - np.insert(_diff, 0, _x[0]) * 0.5
+                # Howver, UniformLinescan always starts at x0 = 0
+                # To conform with this convention, here we now simply remove the
+                # first grid point's absolute position.
+                _x -= _x[0]
 
             # try extracting simple roughness metrics from first column
             _roughness_metrics_list = list(_dataset_df[~_dataset_df[0].isnull()][0].apply(

--- a/test/IO/test_mitutoyo.py
+++ b/test/IO/test_mitutoyo.py
@@ -49,7 +49,7 @@ def test_read_nonuniform(file_format_examples):
     assert nx == 960
     # very different rms height for slightly modified position compared to uniform line scan
     # This is not a bug, but due to approximation methods
-    np.testing.assert_almost_equal(topography.rms_height_from_profile(), 0.13711646786253162)
+    np.testing.assert_almost_equal(topography.rms_height_from_profile(), 0.1371261153644389)
     assert not topography.is_uniform
 
 
@@ -69,17 +69,16 @@ def test_uniform_vs_nonuniform(file_format_examples):
     # but currently it must be
     np.testing.assert_almost_equal(uniform_topography.physical_sizes[0], nonuniform_topography.physical_sizes[0] + 0.5)
 
-    # Convention is to have uniform linescan begin at zero, nonuniform linescan built from Mitutoyo file
-    # chooses positions element-centered, i.e. assumes the initial element to stretch from 0 (zero) to 0.5
-    # and places the grid point centered at 0.25. Similarly, the end point is placed at 479.75 um.
-    np.testing.assert_almost_equal(uniform_x[:99], nonuniform_x[:99] - 0.25)
+    # Convention is to have uniform linescan begin at zero, nonuniform linescan
+    # built from Mitutoyo file follows this convention as well by removing the
+    # initial grid point's absolute position
+    np.testing.assert_almost_equal(uniform_x[:99], nonuniform_x[:99])
 
-    # the 100th positions has been slightly shifted by 0.1 um in the nonuniform mock file
-    # hence centered positions are off at index 100 and 101 by half the shift, 0.05 um:
-    np.testing.assert_almost_equal(uniform_x[99], nonuniform_x[99] - 0.25 - 0.05)
-    np.testing.assert_almost_equal(uniform_x[100], nonuniform_x[100] - 0.25 - 0.05)
+    # the 100th positions has been slightly shifted by 0.1 um in the nonuniform
+    # mock file hence the position is off at index 99
+    np.testing.assert_almost_equal(uniform_x[99], nonuniform_x[99] - 0.1)
 
-    np.testing.assert_almost_equal(uniform_x[101:], nonuniform_x[101:] - 0.25)
+    np.testing.assert_almost_equal(uniform_x[100:], nonuniform_x[100:])
 
     # heights must be the same
     np.testing.assert_almost_equal(nonuniform_h, nonuniform_h)


### PR DESCRIPTION
* Correct position distribution for uniform line scan
* Zero-terminated positions for nonuniform line scan

Produces uniform linescans that reproduce a grid with the same spacing as originally specified in the input file and converges the behavior a little on when constructing `UniformLineScan` and `NonUniformLineScan` of similar data.