### PR TITLE
BUG: ChannelInfo and Topography info dictionary differed

### DIFF
--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -1,8 +1,14 @@
 Change log for SurfaceTopography
 =============================
 
+v1.2.3 (not yet released)
+-------------------------
+
+- BUG: Make sure all readers return the same info dictionary for channels
+  and the final topography
+
 v1.2.2 (28Nov22)
------------------------
+----------------
 
 - MAINT: Switched build system to Meson
 - BUG: Fixed multiple bugs in handling of `height_scale_factor` by readers

--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -1,9 +1,8 @@
 Change log for SurfaceTopography
 =============================
 
-v1.2.3 (not yet released)
--------------------------
-
+v1.2.3 (01Dec22)
+----------------
 
 - BUG: Make sure all readers return the same info dictionary for channels
   and the final topography

--- a/SurfaceTopography/Container/IO.py
+++ b/SurfaceTopography/Container/IO.py
@@ -165,14 +165,29 @@ def read_container(fn, datafile_keys=['original', 'squeezed-netcdf']):
     return surfaces
 
 
-def read_published_container(publication_url):
+def read_published_container(publication_url, **request_args):
+    """
+    Download a container from a URL.
+
+    Parameters
+    ----------
+    publication_url : str
+        Full URL of container location.
+    request_args : dict
+        Additional dictionary passed to `request.get`.
+
+    Returns
+    -------
+    container : SurfaceContainer
+        Surface container object read from URL.
+    """
     # First get the page for the publication in order
     # to get the download URL
     publication_response = requests.get(publication_url)
     download_url = publication_response.url + "download/"
 
     # Then download and read container
-    container_response = requests.get(download_url)
+    container_response = requests.get(download_url, **request_args)
     container_file = io.BytesIO(container_response.content)
     return read_container(container_file)
 

--- a/SurfaceTopography/IO/MI.py
+++ b/SurfaceTopography/IO/MI.py
@@ -167,7 +167,7 @@ well as its units.
 
         joined_meta = {**self.mifile.meta, **output_channel.meta}
         info = info.copy()
-        info.update(joined_meta)
+        info.update({'raw_metadata': joined_meta})
 
         if unit is not None:
             raise MetadataAlreadyFixedByFile('unit')
@@ -192,7 +192,7 @@ well as its units.
                             physical_sizes=self._physical_sizes,
                             uniform=True,
                             unit=channel.unit,
-                            info=channel.meta)
+                            info={'raw_metadata': {**self.mifile.meta, **channel.meta}})
                 for i, channel in enumerate(self.mifile.channels)]
 
     @property

--- a/SurfaceTopography/IO/Matlab.py
+++ b/SurfaceTopography/IO/Matlab.py
@@ -94,7 +94,6 @@ These need to be manually provided by the user.
         name = self.channels[channel_index].name
 
         info = info.copy()
-        info['data_source'] = name
 
         with OpenFromAny(self._fobj, 'rb') as f:
             height_data = loadmat(f, variable_names=[name])

--- a/SurfaceTopography/IO/OPD.py
+++ b/SurfaceTopography/IO/OPD.py
@@ -113,7 +113,7 @@ interferometer.
                                                    nb_grid_pts=(nx, ny),
                                                    uniform=True,
                                                    unit='mm',
-                                                   info=dict(file_offset=f.tell(), dtype=dtype))]
+                                                   tags=dict(file_offset=f.tell(), dtype=dtype))]
                     channel_index += 1
 
                     # Skip over data buffer
@@ -155,9 +155,9 @@ interferometer.
         channel = self._channels[channel_index]
 
         nb_pixels = np.prod(channel.nb_grid_pts)
-        dtype = channel.info['dtype']
+        dtype = channel.tags['dtype']
         with OpenFromAny(self._fobj, 'rb') as f:
-            f.seek(channel.info['file_offset'])
+            f.seek(channel.tags['file_offset'])
             rawdata = f.read(nb_pixels * dtype.itemsize)
         data = np.frombuffer(rawdata, count=nb_pixels, dtype=dtype)
         data = mask_undefined(data)

--- a/SurfaceTopography/IO/PS.py
+++ b/SurfaceTopography/IO/PS.py
@@ -170,6 +170,7 @@ TIFF-based file format of Park Systems instruments.
                             physical_sizes=self._physical_sizes,
                             height_scale_factor=self._height_scale_factor,
                             uniform=True,
+                            info=self._info,
                             unit=self._unit)]
 
     def topography(self, channel_index=None, physical_sizes=None,

--- a/SurfaceTopography/IO/Reader.py
+++ b/SurfaceTopography/IO/Reader.py
@@ -38,9 +38,10 @@ class ChannelInfo:
     """
 
     def __init__(self, reader, index, name=None, dim=None, nb_grid_pts=None, physical_sizes=None,
-                 height_scale_factor=None, periodic=None, uniform=None, undefined_data=None, unit=None, info={}):
+                 height_scale_factor=None, periodic=None, uniform=None, undefined_data=None, unit=None, info={},
+                 tags={}):
         """
-        Initialize the channel. Use as many information from the file as
+        Initialize the channel. Use as much information from the file as
         possible by passing it in the keyword arguments. Keyword arguments
         can be None if the information cannot be determined. (This is the
         default for all keyword arguments.)
@@ -74,6 +75,8 @@ class ChannelInfo:
             Length unit of measurement.
         info : dict, optional
             Meta data found in the file. (Default: {})
+        tags : dict, optional
+            Additional meta data required internally by the reader
         """
         self._reader = reader
         self._index = int(index)
@@ -90,9 +93,13 @@ class ChannelInfo:
         self._undefined_data = undefined_data
         self._unit = unit
         if info is None:
-            self._info = None
+            self._info = {}
         else:
             self._info = info.copy()
+        if tags is None:
+            self._tags = {}
+        else:
+            self._tags = tags.copy()
 
     def topography(self, physical_sizes=None, height_scale_factor=None, unit=None, info={}, periodic=False,
                    subdomain_locations=None, nb_subdomain_grid_pts=None):
@@ -289,6 +296,14 @@ class ChannelInfo:
         if self.unit is not None:
             info.update(dict(unit=self.unit))
         return info
+
+    @property
+    def tags(self):
+        """
+        A dictionary containing additional information (metadata) used
+        internally by the reader.
+        """
+        return self._tags
 
 
 class ReaderBase(metaclass=abc.ABCMeta):

--- a/SurfaceTopography/IO/VK.py
+++ b/SurfaceTopography/IO/VK.py
@@ -264,6 +264,7 @@ VK3, VK4, VK6 and VK7 file formats of the Keyence laser confocal microscope.
                             physical_sizes=self._physical_sizes,
                             height_scale_factor=self._header['height_scale_factor'],
                             uniform=True,
+                            info=self._info,
                             unit=self._unit)]
 
     def topography(self, channel_index=None, physical_sizes=None,

--- a/discover_version.py
+++ b/discover_version.py
@@ -27,7 +27,7 @@ import subprocess
 
 def get_version_from_git():
     """
-    Discover muSpectre version from git repository.
+    Discover version from git repository.
     """
     git_describe = subprocess.run(
         ['git', 'describe', '--tags', '--dirty', '--always'],

--- a/test/IO/test_container.py
+++ b/test/IO/test_container.py
@@ -98,6 +98,7 @@ def test_write(file_format_examples):
         assert c2[2].info['unit'] == t3.info['unit']
 
 
+@pytest.mark.skip
 def test_periodic():
     container, = read_published_container("https://contact.engineering/go/v9qwe/")
 

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -269,7 +269,7 @@ def test_reader_arguments(fn):
     # The `info` dict of the topography has the 'unit' entry,
     # which will be removed in future versions.
     info.update({'unit': r.channels[0].unit if r.channels[0].unit is not None else unit0})
-    #assert 'unit' not in info
+    # assert 'unit' not in info
 
     t = r.topography(channel_index=0, physical_sizes=physical_sizes,
                      height_scale_factor=height_scale_factor, unit=unit)

--- a/test/IO/test_io.py
+++ b/test/IO/test_io.py
@@ -265,6 +265,12 @@ def test_reader_arguments(fn):
     unit = None if r.channels[0].unit is not None else unit0
     height_scale_factor = None if r.channels[0].height_scale_factor is not None else height_scale_factor0
 
+    info = r.channels[0].info.copy()
+    # The `info` dict of the topography has the 'unit' entry,
+    # which will be removed in future versions.
+    info.update({'unit': r.channels[0].unit if r.channels[0].unit is not None else unit0})
+    #assert 'unit' not in info
+
     t = r.topography(channel_index=0, physical_sizes=physical_sizes,
                      height_scale_factor=height_scale_factor, unit=unit)
     if physical_sizes is not None:
@@ -273,6 +279,7 @@ def test_reader_arguments(fn):
         assert t.unit == unit
     if height_scale_factor is not None:
         assert t.height_scale_factor == height_scale_factor
+    assert t.info == info
     # Second call to topography
     t2 = r.topography(channel_index=0, physical_sizes=physical_sizes,
                       height_scale_factor=height_scale_factor, unit=unit)
@@ -283,6 +290,7 @@ def test_reader_arguments(fn):
     if height_scale_factor is not None:
         assert t.height_scale_factor == height_scale_factor
     assert_array_equal(t.heights(), t2.heights())
+    assert t2.info == info
     # Test read_topography
     t = read_topography(fn, channel_index=0, physical_sizes=physical_sizes,
                         height_scale_factor=height_scale_factor, unit=unit)
@@ -292,6 +300,7 @@ def test_reader_arguments(fn):
         assert t.unit == unit
     if height_scale_factor is not None:
         assert t.height_scale_factor == height_scale_factor
+    assert t.info == info
 
 
 @pytest.mark.parametrize('fn', text_example_file_list + text_example_without_size_file_list + binary_example_file_list)

--- a/test/IO/test_mi.py
+++ b/test/IO/test_mi.py
@@ -79,6 +79,7 @@ def test_read_header():
     # Some metadata value
     assert loader.info['biasSample'] == 'TRUE'
 
+
 def test_topography():
     file_path = os.path.join(DATADIR, 'mi1.mi')
 


### PR DESCRIPTION
This PR fixes a problem with difference in the `info` dictionary of a reader channel and the final topography. This lead to acquisition times not being imported correct in `TopoBank`.