### PR TITLE
BUILD: Fix version discovery in published packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Meson dist uses git to create the package - we don't want file format
 # examples in the packages as those are > 100 MB.
 test/file_format_examples export-ignore
+
+# Tags in this file will be replaced during git archive. git archive is used
+# by meson to create source packages.
+discover_version.py export-subst

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/test-source-package.yml
+++ b/.github/workflows/test-source-package.yml
@@ -1,5 +1,15 @@
 name: Test build and install of source package
 
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
 jobs:
   tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-source-package.yml
+++ b/.github/workflows/test-source-package.yml
@@ -1,8 +1,7 @@
 name: Test build and install of source package
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/test-source-package.yml
+++ b/.github/workflows/test-source-package.yml
@@ -1,0 +1,33 @@
+name: Test build and install of source package
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Installing Python
+      run: |
+        sudo apt-get update -qy
+        sudo apt-get install -y \
+          python3-dev \
+          python3-pip \
+          python3-venv \
+          libxml2-dev \
+          libxslt-dev \
+          zlib1g-dev \
+          libfftw3-dev \
+          libopenblas-dev
+        sudo pip install build
+
+    - name: Build package
+      run: |
+        python3 -m build . -s
+
+    - name: Install package
+      run: |
+        pip install dist/*.tar.gz

--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -1,6 +1,11 @@
 Change log for SurfaceTopography
 =============================
 
+v1.2.4 (04Dec22)
+----------------
+
+- BUILD: Fixed version discovery when installing from source package
+
 v1.2.3 (02Dec22)
 ----------------
 

--- a/discover_version.py
+++ b/discover_version.py
@@ -29,17 +29,17 @@
 #   either via importlib.metadata or from pkg_resources. This also holds for
 #   wheels that contain the metadata. We are good! Yay!
 # * If we are not installed, there are two options:
-#   - We are working wihtin the source git repository. Then
+#   - We are working within the source git repository. Then
 #        git describe --tags --always
 #     yields a reasonable version descriptor, but that is unfortunately not
-#     PEP 440 compatible (see https://peps.python.org/pep-0440/). We need to
+#     PEP 440 compliant (see https://peps.python.org/pep-0440/). We need to
 #     mangle the version string to yield something compatible.
 # - If we install from a source tarball, all version information is lost.
 #   Fortunately, Meson uses git archive to create the source tarball, which
 #   replaces certain tags with commit information. Unfortunately, what this
-#   yields is different from git describe - in particular, it only yields the
+#   yields is different from `git describe` - in particular, it only yields the
 #   tag (which contains the version information) if we are *exactly* on the
-#   tag commit. (git describe tells us the distance from the latest tag.) We
+#   tag commit. (`git describe` tells us the distance from the latest tag.) We
 #   need to extract the version information from the string provided, but if
 #   we are not on the tag we can only return a bogus version (here 0.0.0.0).
 #   It works for releases, but not for a tarball generated from a random

--- a/discover_version.py
+++ b/discover_version.py
@@ -22,6 +22,28 @@
 # SOFTWARE.
 #
 
+#
+# This is a minimal-idiotic way of discovering the version. It deals with the
+# following issues:
+# * If we are installed, we can get the version from package metadata,
+#   either via importlib.metadata or from pkg_resources. This also holds for
+#   wheels that contain the metadata. We are good! Yay!
+# * If we are not installed, there are two options:
+#   - We are working wihtin the source git repository. Then
+#        git describe --tags --always
+#     yields a reasonable version descriptor, but that is unfortunately not
+#     PEP 440 compatible (see https://peps.python.org/pep-0440/). We need to
+#     mangle the version string to yield something compatible.
+# - If we install from a source tarball, all version information is lost.
+#   Fortunately, Meson uses git archive to create the source tarball, which
+#   replaces certain tags with commit information. Unfortunately, what this
+#   yields is different from git describe - in particular, it only yields the
+#   tag is we are exactly on the tag commit. We need to extract the version
+#   information from the string provided, but if we are not on the tag we can
+#   only return a bogus version (here 0.0.0.0). It works for releases, but I
+#   am not happy generally.
+#
+
 import re
 import subprocess
 

--- a/discover_version.py
+++ b/discover_version.py
@@ -23,8 +23,8 @@
 #
 
 #
-# This is a minimal-idiotic way of discovering the version. It deals with the
-# following issues:
+# This is the most minimal-idiotic way of discovering the version that I
+# could come up with. It deals with the following issues:
 # * If we are installed, we can get the version from package metadata,
 #   either via importlib.metadata or from pkg_resources. This also holds for
 #   wheels that contain the metadata. We are good! Yay!
@@ -38,10 +38,12 @@
 #   Fortunately, Meson uses git archive to create the source tarball, which
 #   replaces certain tags with commit information. Unfortunately, what this
 #   yields is different from git describe - in particular, it only yields the
-#   tag is we are exactly on the tag commit. We need to extract the version
-#   information from the string provided, but if we are not on the tag we can
-#   only return a bogus version (here 0.0.0.0). It works for releases, but I
-#   am not happy generally.
+#   tag (which contains the version information) if we are *exactly* on the
+#   tag commit. (git describe tells us the distance from the latest tag.) We
+#   need to extract the version information from the string provided, but if
+#   we are not on the tag we can only return a bogus version (here 0.0.0.0).
+#   It works for releases, but not for a tarball generated from a random
+#   commit. I am not happy and open for suggestions.
 #
 
 import re

--- a/discover_version.py
+++ b/discover_version.py
@@ -24,6 +24,9 @@
 
 import subprocess
 
+archived_version = '$Format: %D'
+archived_hash = '$Format: %H'
+
 
 def get_version_from_git():
     """

--- a/discover_version.py
+++ b/discover_version.py
@@ -24,8 +24,8 @@
 
 import subprocess
 
-archived_version = '$Format: %D'
-archived_hash = '$Format: %H'
+archived_version = '$Format:%D$'
+archived_hash = '$Format:%H$'
 
 
 def get_version_from_git():

--- a/discover_version.py
+++ b/discover_version.py
@@ -99,7 +99,11 @@ def get_version_from_git():
 try:
     dirty, version, hash = get_archived_version()
 except CannotDiscoverVersion:
-    dirty, version, hash = get_version_from_git()
+    try:
+        dirty, version, hash = get_version_from_git()
+    except CannotDiscoverVersion:
+        # We return version 0.0.0.0 if version discovery fails
+        version = '0.0.0.0'
 
 #
 # Print version to screen

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -33,22 +33,27 @@ a parameter after a symbol (e.g. `lambda`) but rather say that it is
 Development branches
 ====================
 
-New features should be developed always in its own branch. When creating your own branch,
-please suffix that branch by the year of creation on a description of what is contains.
-For example, if you are working on an implementation for line scans and you started that
-work in 2018, the branch could be called "18_line_scans".
+New features should be developed always in its own branch. When creating your
+own branch, please suffix that branch by the year of creation on a
+description of what is contains. For example, if you are working on an
+implementation for hyperdimensional scans and you started that work in 2048,
+the branch could be called "48_hyperdimensional_scans".
 
 Commits
 =======
 
-Prepend you commits with a shortcut indicating the type of changes they contain:
+Prepend your commits and merge requests with a shortcut indicating the type
+of changes they contain:
 
-- ENH: Enhancement (e.g. a new feature)
-- MAINT: Maintenance (e.g. fixing a typo)
-- DOC: Changes to documentation strings
-- BUG: Bug fix
-- TST: Changes to the unit test environment
-- CI: Changes to the CI configuration
+* API: changes to the user exposed API
+* BUG: Bug fix
+* BUILD: Changes to the build system
+* CI: Changes to the CI configuration
+* DOC: Changes to documentation strings or documentation in general (not only typos)
+* ENH: Enhancement (e.g. a new feature)
+* MAINT: Maintenance (e.g. fixing a typo, or changing code without affecting function)
+* TST: Changes to the unit test environment
+* WIP: Work in progress
 
 The changelog will be based on the content of the commits with tag BUG, API and ENH.
 


### PR DESCRIPTION
Version 1.2.3 introduced version discovery for Meson build. (Version was manually set in 1.2.2.) This PR implements automatic version discovery for source packages.